### PR TITLE
[release-v0.38] Replace docs/reference shortcode with ref URIs

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -12,21 +12,6 @@ cascade:
   AGENT_RELEASE: v0.38.1
   OTEL_VERSION: v0.87.0
 refs:
-  static-mode:
-    - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT_VERSION>/static/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/send-data/agent/static/
-  variants:
-    - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT_VERSION>/about/
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana-cloud/send-data/agent/about/
-  ui:
-    - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
       destination: /docs/agent/<AGENT_VERSION>/operator/
@@ -37,6 +22,21 @@ refs:
       destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
       destination: /docs/agent/<AGENT_VERSION>/flow/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+  variants:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/about/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/about/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
 ---
 
 # Grafana Agent

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,29 +14,29 @@ cascade:
 refs:
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/
   variants:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/about/
+      destination: /docs/agent/<AGENT_VERSION>/about/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/about/
   ui:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/operator/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
 ---
 
 # Grafana Agent

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -11,6 +11,32 @@ weight: 350
 cascade:
   AGENT_RELEASE: v0.38.1
   OTEL_VERSION: v0.87.0
+refs:
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
+  variants:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/about/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/about/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/operator/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
 ---
 
 # Grafana Agent
@@ -55,17 +81,17 @@ Grafana Agent can collect, transform, and send data to:
 * **Battle-tested**: Grafana Agent extends the existing battle-tested code from
   the Prometheus and OpenTelemetry Collector projects.
 * **Powerful**: Write programmable pipelines with ease, and debug them using a
-  [built-in UI][UI].
+  [built-in UI](ref:ui).
 * **Batteries included**: Integrate with systems like MySQL, Kubernetes, and
   Apache to get telemetry that's immediately useful.
 
 ## Getting started
 
-* Choose a [variant][variants] of Grafana Agent to run.
+* Choose a [variant](ref:variants) of Grafana Agent to run.
 * Refer to the documentation for the variant to use:
-  * [Static mode][]
-  * [Static mode Kubernetes operator][]
-  * [Flow mode][]
+  * [Static mode](ref:static-mode)
+  * [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator)
+  * [Flow mode](ref:flow-mode)
 
 ## Supported platforms
 
@@ -101,19 +127,3 @@ one minor release is moved.
 
 Patch and security releases may be created at any time.
 
-{{% docs/reference %}}
-[variants]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/about"
-[variants]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/about"
-
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/operator"
-
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -14,27 +14,27 @@ cascade:
 refs:
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/operator/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   ui:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
   variants:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/about/
+      destination: /docs/agent/<AGENT_VERSION>/about/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/about/
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/
 ---

--- a/docs/sources/_index.md.t
+++ b/docs/sources/_index.md.t
@@ -11,6 +11,32 @@ weight: 350
 cascade:
   AGENT_RELEASE: $AGENT_VERSION
   OTEL_VERSION: v0.87.0
+refs:
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/operator/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+  variants:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/about/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/about/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
 ---
 
 # Grafana Agent
@@ -55,17 +81,17 @@ Grafana Agent can collect, transform, and send data to:
 * **Battle-tested**: Grafana Agent extends the existing battle-tested code from
   the Prometheus and OpenTelemetry Collector projects.
 * **Powerful**: Write programmable pipelines with ease, and debug them using a
-  [built-in UI][UI].
+  [built-in UI](ref:ui).
 * **Batteries included**: Integrate with systems like MySQL, Kubernetes, and
   Apache to get telemetry that's immediately useful.
 
 ## Getting started
 
-* Choose a [variant][variants] of Grafana Agent to run.
+* Choose a [variant](ref:variants) of Grafana Agent to run.
 * Refer to the documentation for the variant to use:
-  * [Static mode][]
-  * [Static mode Kubernetes operator][]
-  * [Flow mode][]
+  * [Static mode](ref:static-mode)
+  * [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator)
+  * [Flow mode](ref:flow-mode)
 
 ## Supported platforms
 
@@ -101,19 +127,3 @@ one minor release is moved.
 
 Patch and security releases may be created at any time.
 
-{{% docs/reference %}}
-[variants]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/about"
-[variants]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/about"
-
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/operator"
-
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -10,6 +10,62 @@ description: Grafana Agent is a flexible, performant, vendor-neutral, telemetry 
 menuTitle: Introduction
 title: Introduction to Grafana Agent
 weight: 100
+refs:
+  static-mode-kubernetes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/operator/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+  flow-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/
+  rules:
+    - pattern: /docs/agent/
+      destination: /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes/
+  loki:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/
+  vault:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault/
+  otel:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/
+  static-mode:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering//
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering//
+  prometheus:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics/
 ---
 
 # Introduction to Grafana Agent
@@ -18,30 +74,10 @@ Grafana Agent is a flexible, high performance, vendor-neutral telemetry collecto
 
 Grafana Agent is available in three different variants:
 
-- [Static mode][]: The original Grafana Agent.
-- [Static mode Kubernetes operator][]: The Kubernetes operator for Static mode.
-- [Flow mode][]: The new, component-based Grafana Agent.
+- [Static mode](ref:static-mode): The original Grafana Agent.
+- [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator): The Kubernetes operator for Static mode.
+- [Flow mode](ref:flow-mode): The new, component-based Grafana Agent.
 
-{{% docs/reference %}}
-[Static mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static"
-[Static mode]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-[Static mode Kubernetes operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator"
-[Static mode Kubernetes operator]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/operator"
-[Flow mode]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow"
-[Flow mode]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow"
-[Prometheus]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics.md"
-[Prometheus]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics.md"
-[OTel]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
-[OTel]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
-[Loki]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md"
-[Loki]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md"
-[clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/_index.md"
-[clustering]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/_index.md"
-[rules]: "/docs/agent/ -> /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes.md"
-[rules]: "/docs/grafana-cloud/ -> /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes.md"
-[vault]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault.md"
-[vault]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/remote.vault.md"
-{{% /docs/reference %}}
 
 [Pyroscope]: https://grafana.com/docs/pyroscope/latest/configure-client/grafana-agent/go_pull
 [helm chart]: https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-k8s-helmchart
@@ -69,9 +105,9 @@ Each variant of Grafana Agent provides a different level of functionality. The f
 
 |              | Grafana Agent Flow mode  | Grafana Agent Static mode | Grafana Agent Operator | OpenTelemetry Collector | Prometheus Agent mode |
 |--------------|--------------------------|---------------------------|------------------------|-------------------------|-----------------------|
-| **Metrics**  | [Prometheus][], [OTel][] | Prometheus                | Prometheus             | OTel                    | Prometheus            |
-| **Logs**     | [Loki][], [OTel][]       | Loki                      | Loki                   | OTel                    | No                    |
-| **Traces**   | [OTel][]                 | OTel                      | OTel                   | OTel                    | No                    |
+| **Metrics**  | [Prometheus](ref:prometheus), [OTel](ref:otel) | Prometheus                | Prometheus             | OTel                    | Prometheus            |
+| **Logs**     | [Loki](ref:loki), [OTel](ref:otel)       | Loki                      | Loki                   | OTel                    | No                    |
+| **Traces**   | [OTel](ref:otel)                 | OTel                      | OTel                   | OTel                    | No                    |
 | **Profiles** | [Pyroscope][]            | No                        | No                     | Planned                 | No                    |
 
 #### **OSS features**
@@ -79,9 +115,9 @@ Each variant of Grafana Agent provides a different level of functionality. The f
 |                          | Grafana Agent Flow mode | Grafana Agent Static mode | Grafana Agent Operator | OpenTelemetry Collector | Prometheus Agent mode |
 |--------------------------|-------------------------|---------------------------|------------------------|-------------------------|-----------------------|
 | **Kubernetes native**    | [Yes][helm chart]       | No                        | Yes                    | Yes                     | No                    |
-| **Clustering**           | [Yes][clustering]       | No                        | No                     | No                      | No                    |
-| **Prometheus rules**     | [Yes][rules]            | No                        | No                     | No                      | No                    |
-| **Native Vault support** | [Yes][vault]            | No                        | No                     | No                      | No                    |
+| **Clustering**           | [Yes](ref:clustering)       | No                        | No                     | No                      | No                    |
+| **Prometheus rules**     | [Yes](ref:rules)            | No                        | No                     | No                      | No                    |
+| **Native Vault support** | [Yes](ref:vault)            | No                        | No                     | No                      | No                    |
 
 #### Grafana Cloud solutions
 
@@ -94,7 +130,7 @@ Each variant of Grafana Agent provides a different level of functionality. The f
 
 ### Static mode
 
-[Static mode][] is the original variant of Grafana Agent, introduced on March 3, 2020.
+[Static mode](ref:static-mode) is the original variant of Grafana Agent, introduced on March 3, 2020.
 Static mode is the most mature variant of Grafana Agent.
 
 You should run Static mode when:
@@ -110,7 +146,7 @@ Grafana Agent version 0.37 and newer provides Prometheus Operator compatibility 
 You should use Grafana Agent Flow mode for all new Grafana Agent deployments.
 {{% /admonition %}}
 
-The [Static mode Kubernetes operator][] is a variant of Grafana Agent introduced on June 17, 2021. It's currently in beta.
+The [Static mode Kubernetes operator](ref:static-mode-kubernetes-operator) is a variant of Grafana Agent introduced on June 17, 2021. It's currently in beta.
 
 The Static mode Kubernetes operator provides compatibility with Prometheus Operator,
 allowing static mode to support resources from Prometheus Operator, such as ServiceMonitors, PodMonitors, and Probes.
@@ -123,7 +159,7 @@ You should run the Static mode Kubernetes operator when:
 
 ### Flow mode
 
-[Flow mode][] is a stable variant of Grafana Agent, introduced on September 29, 2022.
+[Flow mode](ref:flow-mode) is a stable variant of Grafana Agent, introduced on September 29, 2022.
 
 Grafana Agent Flow mode focuses on vendor neutrality, ease-of-use,
 improved debugging, and ability to adapt to the needs of power users by adopting a configuration-as-code model.
@@ -147,10 +183,3 @@ You should run Flow mode when:
 [BoringCrypto](https://pkg.go.dev/crypto/internal/boring) is an **EXPERIMENTAL** feature for building Grafana Agent
 binaries and images with BoringCrypto enabled. Builds and Docker images for Linux arm64/amd64 are made available.
 
-{{% docs/reference %}}
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
-[integrations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/integrations"
-
-[components]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
-[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/about.md
+++ b/docs/sources/about.md
@@ -13,19 +13,19 @@ weight: 100
 refs:
   static-mode-kubernetes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/
+      destination: /docs/agent/<AGENT_VERSION>/operator/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/operator/
   components:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/reference/components/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
   flow-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
   rules:
     - pattern: /docs/agent/
       destination: /docs/agent/latest/flow/reference/components/mimir.rules.kubernetes/
@@ -48,12 +48,12 @@ refs:
       destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/
   static-mode:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/
+      destination: /docs/agent/<AGENT_VERSION>/static/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/
   clustering:

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -46,9 +46,9 @@ The usage information includes the following details:
 * Version of running Grafana Agent.
 * Operating system Grafana Agent is running on.
 * System architecture Grafana Agent is running on.
-* List of enabled feature flags [Static](ref:static) mode only).
-* List of enabled integrations [Static](ref:static) mode only).
-* List of enabled [components](ref:components) [Flow](ref:flow) mode only).
+* List of enabled feature flags ([Static](ref:static) mode only).
+* List of enabled integrations ([Static](ref:static) mode only).
+* List of enabled [components](ref:components) ([Flow](ref:flow) mode only).
 * Method used to deploy Grafana Agent, for example Docker, Helm, RPM, or Operator.
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.

--- a/docs/sources/data-collection.md
+++ b/docs/sources/data-collection.md
@@ -10,6 +10,25 @@ description: Grafana Agent data collection
 menuTitle: Data collection
 title: Grafana Agent data collection
 weight: 500
+refs:
+  static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/
+  flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+  command-line-flag:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
 ---
 
 # Grafana Agent Data collection
@@ -27,24 +46,14 @@ The usage information includes the following details:
 * Version of running Grafana Agent.
 * Operating system Grafana Agent is running on.
 * System architecture Grafana Agent is running on.
-* List of enabled feature flags ([Static] mode only).
-* List of enabled integrations ([Static] mode only).
-* List of enabled [components][] ([Flow] mode only).
+* List of enabled feature flags [Static](ref:static) mode only).
+* List of enabled integrations [Static](ref:static) mode only).
+* List of enabled [components](ref:components) [Flow](ref:flow) mode only).
 * Method used to deploy Grafana Agent, for example Docker, Helm, RPM, or Operator.
 
 This list may change over time. All newly reported data is documented in the CHANGELOG.
 
 ## Opt-out of data collection
 
-You can use the `-disable-reporting` [command line flag][] to disable the reporting and opt-out of the data collection.
+You can use the `-disable-reporting` [command line flag](ref:command-line-flag) to disable the reporting and opt-out of the data collection.
 
-{{% docs/reference %}}
-[command line flag]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[command line flag]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[components]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[Static]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static"
-[Static]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static
-[Flow]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow"
-[Flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT_VERSION>/flow"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/clustering.md
+++ b/docs/sources/flow/concepts/clustering.md
@@ -11,6 +11,42 @@ labels:
 menuTitle: Clustering
 title: Clustering (beta)
 weight: 500
+refs:
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/#clustering-beta
+  debugging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#debugging-clustering-issues
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#debugging-clustering-issues
+  prometheus.operator.servicemonitors:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.servicemonitors/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.servicemonitors/#clustering-beta
+  clustering-page:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#clustering-page
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#clustering-page
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/#clustering-beta
+  prometheus.operator.podmonitors:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.podmonitors/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.podmonitors/#clustering-beta
+  pyroscope.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.scrape/#clustering-beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/pyroscope.scrape/#clustering-beta
 ---
 
 # Clustering (beta)
@@ -23,7 +59,7 @@ To achieve this, {{< param "PRODUCT_NAME" >}} makes use of an eventually consist
 
 The behavior of a standalone, non-clustered {{< param "PRODUCT_ROOT_NAME" >}} is the same as if it were a single-node cluster.
 
-You configure clustering by passing `cluster` command-line flags to the [run][] command.
+You configure clustering by passing `cluster` command-line flags to the [run](ref:run) command.
 
 ## Use cases
 
@@ -55,29 +91,13 @@ It also provides resiliency because targets are automatically picked up by one o
 
 Refer to component reference documentation to discover whether it supports clustering, such as:
 
-- [prometheus.scrape][]
-- [pyroscope.scrape][]
-- [prometheus.operator.podmonitors][]
-- [prometheus.operator.servicemonitors][]
+- [prometheus.scrape](ref:prometheus.scrape)
+- [pyroscope.scrape](ref:pyroscope.scrape)
+- [prometheus.operator.podmonitors](ref:prometheus.operator.podmonitors)
+- [prometheus.operator.servicemonitors](ref:prometheus.operator.servicemonitors)
 
 ## Cluster monitoring and troubleshooting
 
-You can use the {{< param "PRODUCT_NAME" >}} UI [clustering page][] to monitor your cluster status.
-Refer to [Debugging clustering issues][debugging] for additional troubleshooting information.
+You can use the {{< param "PRODUCT_NAME" >}} UI [clustering page](ref:clustering-page) to monitor your cluster status.
+Refer to [Debugging clustering issues](ref:debugging) for additional troubleshooting information.
 
-{{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md#clustering-beta"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md#clustering-beta"
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md#clustering-beta"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md#clustering-beta"
-[pyroscope.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/pyroscope.scrape.md#clustering-beta"
-[pyroscope.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/pyroscope.scrape.md#clustering-beta"
-[prometheus.operator.podmonitors]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.podmonitors.md#clustering-beta"
-[prometheus.operator.podmonitors]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.podmonitors.md#clustering-beta"
-[prometheus.operator.servicemonitors]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.operator.servicemonitors.md#clustering-beta"
-[prometheus.operator.servicemonitors]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.operator.servicemonitors.md#clustering-beta"
-[clustering page]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#clustering-page"
-[clustering page]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#clustering-page"
-[debugging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#debugging-clustering-issues"
-[debugging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#debugging-clustering-issues"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/component_controller.md
+++ b/docs/sources/flow/concepts/component_controller.md
@@ -9,6 +9,22 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/component_control
 description: Learn about the component controller
 title: Component controller
 weight: 200
+refs:
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  prometheus.exporter.unix:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.exporter.unix/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.exporter.unix/
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
 ---
 
 # Component controller
@@ -24,7 +40,7 @@ The component controller is responsible for:
 
 ## Component graph
 
-A relationship between [components][Components] is created when an expression is used to set the argument of one component to an exported field of another component.
+A relationship between [components](ref:components) is created when an expression is used to set the argument of one component to an exported field of another component.
 
 The set of all components and the relationships between them define a [Directed Acyclic Graph][DAG] (DAG),
 which informs the component controller which references are valid and in what order components must be evaluated.
@@ -59,7 +75,7 @@ Components that don't depend on other components can be evaluated anytime during
 
 ## Component reevaluation
 
-A [component][Components] is dynamic. A component can update its exports any number of times throughout its lifetime.
+A [component](ref:components) is dynamic. A component can update its exports any number of times throughout its lifetime.
 
 A _controller reevaluation_ is triggered when a component updates its exports.
 The component controller reevaluates any component that references the changed component, any components that reference those components,
@@ -97,11 +113,11 @@ If your `local.file` component, which watches API keys, suddenly stops working, 
 
 ## In-memory traffic
 
-Components that expose HTTP endpoints, such as [prometheus.exporter.unix][], can expose an internal address that completely bypasses the network and communicate in-memory.
+Components that expose HTTP endpoints, such as [prometheus.exporter.unix](ref:prometheus.exporter.unix), can expose an internal address that completely bypasses the network and communicate in-memory.
 Components within the same process can communicate with one another without needing to be aware of any network-level protections such as authentication or mutual TLS.
 
 The internal address defaults to `agent.internal:12345`.
-If this address collides with a real target on your network, change it to something unique using the `--server.http.memory-addr` flag in the [run][] command.
+If this address collides with a real target on your network, change it to something unique using the `--server.http.memory-addr` flag in the [run](ref:run) command.
 
 Components must opt-in to using in-memory traffic.
 Refer to the individual documentation for components to learn if in-memory traffic is supported.
@@ -115,11 +131,3 @@ All components managed by the controller are reevaluated after reloading.
 
 [DAG]: https://en.wikipedia.org/wiki/Directed_acyclic_graph
 
-{{% docs/reference %}}
-[prometheus.exporter.unix]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.exporter.unix.md"
-[prometheus.exporter.unix]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.exporter.unix.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/configuration_language.md
+++ b/docs/sources/flow/concepts/configuration_language.md
@@ -9,6 +9,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/configuration_lan
 description: Learn about configuration language concepts
 title: Configuration language concepts
 weight: 400
+refs:
+  config-docs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/
 ---
 
 # Configuration language concepts
@@ -88,9 +94,5 @@ The preceding example has two blocks:
 
 ## More information
 
-Refer to [Configuration language][config-docs] for more information about River.
+Refer to [Configuration language](ref:config-docs) for more information about River.
 
-{{% docs/reference %}}
-[config-docs]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language"
-[config-docs]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language"
-{{% /docs/reference %}}

--- a/docs/sources/flow/concepts/modules.md
+++ b/docs/sources/flow/concepts/modules.md
@@ -9,6 +9,27 @@ canonical: https://grafana.com/docs/agent/latest/flow/concepts/modules/
 description: Learn about modules
 title: Modules
 weight: 300
+refs:
+  export-block:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/export/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/export/
+  argument-block:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/argument/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/argument/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/
+  component-controller:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller/
 ---
 
 # Modules
@@ -24,7 +45,7 @@ Modules are {{< param "PRODUCT_NAME" >}} configurations which have:
 
 You use a [Module loader][] to load Modules into {{< param "PRODUCT_NAME" >}}.
 
-Refer to [argument block][] and [export block][] to learn how to define arguments and exports for a module.
+Refer to [argument block](ref:argument-block) and [export block](ref:export-block) to learn how to define arguments and exports for a module.
 
 ## Module loaders
 
@@ -33,7 +54,7 @@ A _Module loader_ is a {{< param "PRODUCT_NAME" >}} component that retrieves a m
 Module loader components are responsible for the following functions:
 
 * Retrieving the module source.
-* Creating a [Component controller][] for the module.
+* Creating a [Component controller](ref:component-controller) for the module.
 * Passing arguments to the loaded module.
 * Exposing exports from the loaded module.
 
@@ -43,7 +64,7 @@ Module loaders are typically called `module.LOADER_NAME`.
 Some module loaders may not support running modules with arguments or exports.
 {{% /admonition %}}
 
-Refer to [Components][] for more information about the module loader components.
+Refer to [Components](ref:components) for more information about the module loader components.
 
 ## Module sources
 
@@ -135,13 +156,3 @@ loki.write "default" {
 
 [Module loader]: #module-loaders
 
-{{% docs/reference %}}
-[argument block]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/argument.md"
-[argument block]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/argument.md"
-[export block]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/export.md"
-[export block]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/export.md"
-[Component controller]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller.md"
-[Component controller]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/_index.md
+++ b/docs/sources/flow/config-language/_index.md
@@ -9,6 +9,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/
 description: Learn about the configuration language
 title: Configuration language
 weight: 400
+refs:
+  fmt:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/fmt/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/fmt/
 ---
 
 # Configuration language
@@ -62,7 +68,7 @@ You can use one or all of the following tools to help you write configuration fi
   * [vim](https://github.com/rfratto/vim-river)
   * [VSCode](https://github.com/rfratto/vscode-river)
   * [river-mode](https://github.com/jdbaldry/river-mode) for Emacs
-* Code formatting using the [`agent fmt` command][fmt]
+* Code formatting using the [`agent fmt` command](ref:fmt)
 
 You can also start developing your own tooling using the {{< param "PRODUCT_ROOT_NAME" >}} repository as a go package or use the
 [tree-sitter grammar][] with other programming languages.
@@ -73,7 +79,3 @@ You can also start developing your own tooling using the {{< param "PRODUCT_ROOT
 [river-mode]: https://github.com/jdbaldry/river-mode
 [tree-sitter grammar]: https://github.com/grafana/tree-sitter-river
 
-{{% docs/reference %}}
-[fmt]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/fmt"
-[fmt]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/fmt"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/components.md
+++ b/docs/sources/flow/config-language/components.md
@@ -9,6 +9,22 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/components
 description: Learn about the components configuration language
 title: Components configuration language
 weight: 300
+refs:
+  type:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/
+  controller:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/
 ---
 
 # Components configuration language
@@ -17,11 +33,11 @@ Components are the defining feature of {{< param "PRODUCT_NAME" >}}.
 Components are small, reusable pieces of business logic that perform a single task like retrieving secrets or collecting Prometheus metrics,
 and you can wire them together to form programmable pipelines of telemetry data.
 
-The [_component controller_][controller] is responsible for scheduling components, reporting their health and debug status, re-evaluating their arguments, and providing their exports.
+The [_component controller_](ref:controller) is responsible for scheduling components, reporting their health and debug status, re-evaluating their arguments, and providing their exports.
 
 ## Configuring components
 
-You create [components][] by defining a top-level River block.
+You create [components](ref:components) by defining a top-level River block.
 All components are identified by their name, describing what the component is responsible for, and a user-specified _label_.
 
 ## Arguments and exports
@@ -81,18 +97,10 @@ prometheus.scrape "default" {
 
 Each time the file contents change, the `local.file` updates its exports. The new value is sent to the `prometheus.scrape` targets field.
 
-Each argument and exported field has an underlying [type][].
+Each argument and exported field has an underlying [type](ref:type).
 River checks the expression type before assigning a value to an attribute.
-The documentation of each [component][components] provides more information about how to wire components together.
+The documentation of each [component](ref:components) provides more information about how to wire components together.
 
 In the previous example, the contents of the `local.file.targets.content` expression is evaluated to a concrete value.
 The value is type-checked and substituted into `prometheus.scrape.default`, where you can configure it.
 
-{{% docs/reference %}}
-[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components"
-[components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-[controller]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller"
-[controller]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller"
-[type]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values"
-[type]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/expressions/_index.md
+++ b/docs/sources/flow/config-language/expressions/_index.md
@@ -9,6 +9,22 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/expression
 description: Learn about expressions
 title: Expressions
 weight: 400
+refs:
+  refer-to-values:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/referencing_exports/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/referencing_exports/
+  type:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/
+  call-functions:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/function_calls/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/function_calls/
 ---
 
 # Expressions
@@ -16,17 +32,9 @@ weight: 400
 Expressions represent or compute values you can assign to attributes within a configuration.
 
 Basic expressions are literal values, like `"Hello, world!"` or `true`.
-Expressions may also do things like [refer to values][] exported by components, perform arithmetic, or [call functions][].
+Expressions may also do things like [refer to values](ref:refer-to-values) exported by components, perform arithmetic, or [call functions](ref:call-functions).
 
 You use expressions when you configure any component.
-All component arguments have an underlying [type][].
+All component arguments have an underlying [type](ref:type).
 River checks the expression type before assigning the result to an attribute.
 
-{{% docs/reference %}}
-[refer to values]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/referencing_exports"
-[refer to values]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/referencing_exports"
-[call functions]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/function_calls"
-[call functions]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/function_calls"
-[type]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values"
-[type]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/expressions/function_calls.md
+++ b/docs/sources/flow/config-language/expressions/function_calls.md
@@ -9,6 +9,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/expression
 description: Learn about function calls
 title: Function calls
 weight: 400
+refs:
+  standard-library:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/stdlib/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/stdlib/
 ---
 
 # Function calls
@@ -22,7 +28,7 @@ If a function fails, the expression isn't evaluated, and an error is reported.
 
 ## Standard library functions
 
-River contains a [standard library][] of functions.
+River contains a [standard library](ref:standard-library) of functions.
 Some functions enable interaction with the host system, for example, reading from an environment variable.
 Some functions allow for more complex expressions, for example, concatenating arrays or decoding JSON strings into objects.
 
@@ -31,7 +37,3 @@ env("HOME")
 json_decode(local.file.cfg.content)["namespace"]
 ```
 
-{{% docs/reference %}}
-[standard library]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/stdlib"
-[standard library]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/stdlib"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/expressions/referencing_exports.md
+++ b/docs/sources/flow/config-language/expressions/referencing_exports.md
@@ -9,6 +9,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/expression
 description: Learn about referencing component exports
 title: Referencing component exports
 weight: 200
+refs:
+  type:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/
 ---
 
 # Referencing component exports
@@ -50,11 +56,7 @@ In the preceding example, you wired together a very simple pipeline by writing a
 
 ![Flow of example pipeline](/media/docs/agent/flow_referencing_exports_diagram.svg)
 
-After the value is resolved, it must match the [type][] of the attribute it is assigned to.
+After the value is resolved, it must match the [type](ref:type) of the attribute it is assigned to.
 While you can only configure attributes using the basic River types,
 the exports of components can take on special internal River types, such as Secrets or Capsules, which expose different functionality.
 
-{{% docs/reference %}}
-[type]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values"
-[type]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/expressions/types_and_values.md
+++ b/docs/sources/flow/config-language/expressions/types_and_values.md
@@ -9,6 +9,12 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/expression
 description: Learn about the River types and values
 title: Types and values
 weight: 100
+refs:
+  type:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/
 ---
 
 # Types and values
@@ -212,7 +218,3 @@ prometheus.scrape "default" {
 }
 ```
 
-{{% docs/reference %}}
-[type]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components"
-[type]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/flow/config-language/syntax.md
+++ b/docs/sources/flow/config-language/syntax.md
@@ -9,6 +9,17 @@ canonical: https://grafana.com/docs/agent/latest/flow/config-language/syntax/
 description: Learn about the River syntax
 title: Syntax
 weight: 200
+refs:
+  expression:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/
+  type:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/
 ---
 
 # Syntax
@@ -44,8 +55,8 @@ log_level = "debug"
 
 The `ATTRIBUTE_NAME` must be a valid River [identifier][].
 
-The `ATTRIBUTE_VALUE` can be either a constant value of a valid River [type][] (for example, a string, boolean, number),
-or an [_expression_][expression] to represent or compute more complex attribute values.
+The `ATTRIBUTE_VALUE` can be either a constant value of a valid River [type](ref:type) (for example, a string, boolean, number),
+or an [_expression_](ref:expression) to represent or compute more complex attribute values.
 
 ### Blocks
 
@@ -111,9 +122,3 @@ River ignores other newlines and you can can enter as many newlines as you want.
 [identifier]: #identifiers
 [identifier]: #identifiers
 
-{{% docs/reference %}}
-[expression]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions"
-[expression]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions"
-[type]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values"
-[type]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/collect-opentelemetry-data.md
+++ b/docs/sources/flow/getting-started/collect-opentelemetry-data.md
@@ -8,6 +8,37 @@ canonical: https://grafana.com/docs/agent/latest/flow/getting-started/collect-op
 description: Learn how to collect OpenTelemetry data
 title: Collect OpenTelemetry data
 weight: 300
+refs:
+  otelcol.receiver.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp/
+  otelcol.exporter.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp/
+  otelcol.auth.basic:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic/
+  otelcol.exporter.otlphttp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlphttp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlphttp/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  otelcol.processor.batch:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch/
 ---
 
 # Collect OpenTelemetry data
@@ -23,11 +54,11 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [otelcol.auth.basic][]
-* [otelcol.exporter.otlp][]
-* [otelcol.exporter.otlphttp][]
-* [otelcol.processor.batch][]
-* [otelcol.receiver.otlp][]
+* [otelcol.auth.basic](ref:otelcol.auth.basic)
+* [otelcol.exporter.otlp](ref:otelcol.exporter.otlp)
+* [otelcol.exporter.otlphttp](ref:otelcol.exporter.otlphttp)
+* [otelcol.processor.batch](ref:otelcol.processor.batch)
+* [otelcol.receiver.otlp](ref:otelcol.receiver.otlp)
 
 ## Before you begin
 
@@ -35,7 +66,7 @@ This topic describes how to:
   OpenTelemetry.
 * Have a set of OpenTelemetry applications ready to push telemetry data to {{< param "PRODUCT_NAME" >}}.
 * Identify where {{< param "PRODUCT_NAME" >}} will write received telemetry data.
-* Be familiar with the concept of [Components][] in {{< param "PRODUCT_NAME" >}}.
+* Be familiar with the concept of [Components](ref:components) in {{< param "PRODUCT_NAME" >}}.
 
 ## Configure an OpenTelemetry Protocol exporter
 
@@ -44,12 +75,12 @@ responsible for exporting the OpenTelemetry data. An OpenTelemetry _exporter
 component_ is responsible for writing (that is, exporting) OpenTelemetry data
 to an external system.
 
-In this task, we will use the [otelcol.exporter.otlp][] component to send
+In this task, we will use the [otelcol.exporter.otlp](ref:otelcol.exporter.otlp) component to send
 OpenTelemetry data to a server using the OpenTelemetry Protocol (OTLP). Once an
 exporter component is defined, other {{< param "PRODUCT_NAME" >}} components can be used
 to forward data to it.
 
-> Refer to the list of available [Components][] for the full list of
+> Refer to the list of available [Components](ref:components) for the full list of
 > `otelcol.exporter` components that can be used to export OpenTelemetry data.
 
 To configure an `otelcol.exporter.otlp` component for exporting OpenTelemetry
@@ -110,7 +141,7 @@ data using OTLP, complete the following steps:
 
 > `otelcol.exporter.otlp` sends data using OTLP over gRPC (HTTP/2). To send to
 > a server using HTTP/1.1, follow the steps above but use the
-> [otelcol.exporter.otlphttp component][otelcol.exporter.otlphttp] instead.
+> [otelcol.exporter.otlphttp component](ref:otelcol.exporter.otlphttp) instead.
 
 The following example demonstrates configuring `otelcol.exporter.otlp` with
 authentication and a component which forwards data to it:
@@ -148,7 +179,7 @@ otelcol.receiver.otlp "example" {
 ```
 
 For more information on writing OpenTelemetry data using the OpenTelemetry
-Protocol, refer to [otelcol.exporter.otlp][].
+Protocol, refer to [otelcol.exporter.otlp](ref:otelcol.exporter.otlp).
 
 ## Configure batching
 
@@ -161,10 +192,10 @@ Ensuring data is batched is a production-readiness step to improve the
 compression of data and reduce the number of outgoing network requests to
 external systems.
 
-In this task, we will configure an [otelcol.processor.batch][] component to
+In this task, we will configure an [otelcol.processor.batch](ref:otelcol.processor.batch) component to
 batch data before sending it to our exporter.
 
-> Refer to the list of available [Components][] for the full list of
+> Refer to the list of available [Components](ref:components) for the full list of
 > `otelcol.processor` components that can be used to process OpenTelemetry
 > data. You can chain processors by having one processor send data to another
 > processor.
@@ -233,7 +264,7 @@ otelcol.exporter.otlp "default" {
 ```
 
 For more information on configuring OpenTelemetry data batching, refer to
-[otelcol.processor.batch][].
+[otelcol.processor.batch](ref:otelcol.processor.batch).
 
 ## Configure an OpenTelemetry Protocol receiver
 
@@ -241,11 +272,11 @@ For more information on configuring OpenTelemetry data batching, refer to
 and traces. An OpenTelemetry _receiver_ component is responsible for receiving
 OpenTelemetry data from an external system.
 
-In this task, we will use the [otelcol.receiver.otlp][] component to receive
+In this task, we will use the [otelcol.receiver.otlp](ref:otelcol.receiver.otlp) component to receive
 OpenTelemetry data over the network using the OpenTelemetry Protocol (OTLP). A
 receiver component can be configured to forward received data to other {{< param "PRODUCT_NAME" >}} components.
 
-> Refer to the list of available [Components][] for the full list of
+> Refer to the list of available [Components](ref:components) for the full list of
 > `otelcol.receiver` components that can be used to receive
 > OpenTelemetry-compatible data.
 
@@ -350,21 +381,7 @@ otelcol.exporter.otlp "default" {
 ```
 
 For more information on receiving OpenTelemetry data using the OpenTelemetry
-Protocol, refer to [otelcol.receiver.otlp][].
+Protocol, refer to [otelcol.receiver.otlp](ref:otelcol.receiver.otlp).
 
 [OpenTelemetry]: https://opentelemetry.io
 
-{{% docs/reference %}}
-[otelcol.auth.basic]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.auth.basic]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.exporter.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.otlphttp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlphttp.md"
-[otelcol.exporter.otlphttp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlphttp.md"
-[otelcol.processor.batch]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.processor.batch]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.receiver.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp.md"
-[otelcol.receiver.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/collect-prometheus-metrics.md
+++ b/docs/sources/flow/getting-started/collect-prometheus-metrics.md
@@ -8,6 +8,32 @@ canonical: https://grafana.com/docs/agent/latest/flow/getting-started/collect-pr
 description: Learn how to collect and forward Prometheus metrics
 title: Collect and forward Prometheus metrics
 weight: 200
+refs:
+  discovery.kubernetes:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/discovery.kubernetes/
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  objects:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/#objects
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/#objects
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
 ---
 
 # Collect and forward Prometheus metrics
@@ -22,9 +48,9 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [discovery.kubernetes][]
-* [prometheus.remote_write][]
-* [prometheus.scrape][]
+* [discovery.kubernetes](ref:discovery.kubernetes)
+* [prometheus.remote_write](ref:prometheus.remote_write)
+* [prometheus.scrape](ref:prometheus.scrape)
 
 ## Before you begin
 
@@ -35,14 +61,14 @@ This topic describes how to:
 * Identify where you will write collected metrics. Metrics may be written to
   Prometheus or Prometheus-compatible endpoints such as Grafana Mimir, Grafana
   Cloud, or Grafana Enterprise Metrics.
-* Be familiar with the concept of [Components][] in {{< param "PRODUCT_NAME" >}}.
+* Be familiar with the concept of [Components](ref:components) in {{< param "PRODUCT_NAME" >}}.
 
 ## Configure metrics delivery
 
 Before components can collect Prometheus metrics, you must have a component
 responsible for writing those metrics somewhere.
 
-The [prometheus.remote_write][] component is responsible for delivering
+The [prometheus.remote_write](ref:prometheus.remote_write) component is responsible for delivering
 Prometheus metrics to one or Prometheus-compatible endpoints. Once a
 `prometheus.remote_write` component is defined, other {{< param "PRODUCT_NAME" >}}
 components can be used to forward metrics to it.
@@ -118,7 +144,7 @@ prometheus.scrape "example" {
 ```
 
 For more information on configuring metrics delivery, refer to
-[prometheus.remote_write][].
+[prometheus.remote_write](ref:prometheus.remote_write).
 
 ## Collect metrics from Kubernetes Pods
 
@@ -257,7 +283,7 @@ prometheus.remote_write "default" {
 ```
 
 For more information on configuring Kubernetes service delivery and collecting
-metrics, refer to [discovery.kubernetes][] and [prometheus.scrape][].
+metrics, refer to [discovery.kubernetes](ref:discovery.kubernetes) and [prometheus.scrape](ref:prometheus.scrape).
 
 ## Collect metrics from Kubernetes Services
 
@@ -396,7 +422,7 @@ prometheus.remote_write "default" {
 ```
 
 For more information on configuring Kubernetes service delivery and collecting
-metrics, refer to [discovery.kubernetes][] and [prometheus.scrape][].
+metrics, refer to [discovery.kubernetes](ref:discovery.kubernetes) and [prometheus.scrape](ref:prometheus.scrape).
 
 ## Collect metrics from custom targets
 
@@ -421,7 +447,7 @@ To collect metrics from a custom set of targets, complete the following steps:
         `custom_targets`. The label chosen must be unique across all
         `prometheus.scrape` components in the same configuration file.
 
-     2. Replace `TARGET_LIST` with a comma-delimited list of [Objects][]
+     2. Replace `TARGET_LIST` with a comma-delimited list of [Objects](ref:objects)
         denoting the Prometheus target. Each object must conform to the
         following rules:
 
@@ -486,15 +512,3 @@ prometheus.remote_write "default" {
 [Field Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/
 [Labels and Selectors]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement
 
-{{% docs/reference %}}
-[discovery.kubernetes]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/discovery.kubernetes.md"
-[discovery.kubernetes]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/discovery.kubernetes.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[Objects]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values.md#objects"
-[Objects]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values.md#objects"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/configure-agent-clustering.md
+++ b/docs/sources/flow/getting-started/configure-agent-clustering.md
@@ -9,16 +9,37 @@ description: Learn how to configure Grafana Agent clustering in an existing inst
 menuTitle: Configure Grafana Agent clustering
 title: Configure Grafana Agent clustering in an existing installation
 weight: 400
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#component-detail-page
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#component-detail-page
+  beta:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/stability/#beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/stability/#beta
+  install-helm:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/install/kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/install/kubernetes/
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
 ---
 
 # Configure {{% param "PRODUCT_NAME" %}} clustering in an existing installation
 
-You can configure {{< param "PRODUCT_NAME" >}} to run with [clustering][] so that
+You can configure {{< param "PRODUCT_NAME" >}} to run with [clustering](ref:clustering) so that
 individual {{< param "PRODUCT_ROOT_NAME" >}}s can work together for workload distribution and high
 availability.
 
 
-> **Note:** Clustering is a [beta][] feature. Beta features are subject to breaking changes and may be
+> **Note:** Clustering is a [beta](ref:beta) feature. Beta features are subject to breaking changes and may be
 > replaced with equivalent functionality that covers the same use case.
 
 This topic describes how to add clustering to an existing installation.
@@ -26,7 +47,7 @@ This topic describes how to add clustering to an existing installation.
 ## Configure {{% param "PRODUCT_NAME" %}} clustering with Helm Chart
 
 This section guides you through enabling clustering when {{< param "PRODUCT_NAME" >}} is
-installed on Kubernetes using the {{< param "PRODUCT_ROOT_NAME" >}} [Helm chart][install-helm].
+installed on Kubernetes using the {{< param "PRODUCT_ROOT_NAME" >}} [Helm chart](ref:install-helm).
 
 ### Before you begin
 
@@ -55,19 +76,9 @@ To configure clustering:
    Replace `RELEASE_NAME` with the name of the installation you chose when you
    installed the Helm chart.
 
-1. Use the {{< param "PRODUCT_NAME" >}} [UI][] to verify the cluster status:
+1. Use the {{< param "PRODUCT_NAME" >}} [UI](ref:ui) to verify the cluster status:
 
    1. Click **Clustering** in the navigation bar.
 
    2. Ensure that all expected nodes appear in the resulting table.
 
-{{% docs/reference %}}
-[clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
-[clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[beta]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/stability.md#beta"
-[beta]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/stability.md#beta"
-[install-helm]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/install/kubernetes.md"
-[install-helm]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/install/kubernetes.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#component-detail-page"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#component-detail-page"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
+++ b/docs/sources/flow/getting-started/distribute-prometheus-scrape-load.md
@@ -9,23 +9,54 @@ description: Learn how to distribute your Prometheus metrics scrape load
 menuTitle: Distribute Prometheus metrics scrape load
 title: Distribute Prometheus metrics scrape load
 weight: 500
+refs:
+  configure-prometheus-metrics-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-prometheus-metrics/
+  configure-grafana-agent:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#component-detail-page
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#component-detail-page
+  configure-clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/configure-agent-clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/configure-agent-clustering/
+  beta:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/stability/#beta
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/stability/#beta
 ---
 
 # Distribute Prometheus metrics scrape load
 
 A good predictor for the size of an {{< param "PRODUCT_NAME" >}} deployment is the number of
-Prometheus targets each {{< param "PRODUCT_ROOT_NAME" >}} scrapes. [Clustering][] with target
+Prometheus targets each {{< param "PRODUCT_ROOT_NAME" >}} scrapes. [Clustering](ref:clustering) with target
 auto-distribution allows a fleet of {{< param "PRODUCT_ROOT_NAME" >}}s to work together to dynamically
 distribute their scrape load, providing high-availability.
 
-> **Note:** Clustering is a [beta][] feature. Beta features are subject to breaking
+> **Note:** Clustering is a [beta](ref:beta) feature. Beta features are subject to breaking
 > changes and may be replaced with equivalent functionality that covers the same use case.
 
 ## Before you begin
 
-- Familiarize yourself with how to [configure existing {{< param "PRODUCT_NAME" >}} installations][configure-grafana-agent].
-- [Configure Prometheus metrics collection][].
-- [Configure clustering][].
+- Familiarize yourself with how to [configure existing {{< param "PRODUCT_NAME" >}} installations](ref:configure-grafana-agent).
+- [Configure Prometheus metrics collection](ref:configure-prometheus-metrics-collection).
+- [Configure clustering](ref:configure-clustering).
 - Ensure that all of your clustered {{< param "PRODUCT_ROOT_NAME" >}}s have the same configuration file.
 
 ## Steps
@@ -45,22 +76,8 @@ To distribute Prometheus metrics scrape load with clustering:
 
 1. Validate that auto-distribution is functioning:
 
-   1. Using the {{< param "PRODUCT_ROOT_NAME" >}} [UI][] on each {{< param "PRODUCT_ROOT_NAME" >}}, navigate to the details page for one of
+   1. Using the {{< param "PRODUCT_ROOT_NAME" >}} [UI](ref:ui) on each {{< param "PRODUCT_ROOT_NAME" >}}, navigate to the details page for one of
       the `prometheus.scrape` components you modified.
 
    1. Compare the Debug Info sections between two different {{< param "PRODUCT_ROOT_NAME" >}} to ensure that they're not scraping the same sets of targets.
 
-{{% docs/reference %}}
-[Clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
-[Clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[beta]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/stability.md#beta"
-[beta]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/stability.md#beta"
-[configure-grafana-agent]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure"
-[configure-grafana-agent]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure"
-[Configure Prometheus metrics collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-prometheus-metrics.md"
-[Configure Prometheus metrics collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-prometheus-metrics.md"
-[Configure clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/configure-agent-clustering.md"
-[Configure clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/configure-agent-clustering.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#component-detail-page"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#component-detail-page"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-prometheus.md
+++ b/docs/sources/flow/getting-started/migrating-from-prometheus.md
@@ -9,6 +9,52 @@ description: Learn how to migrate from Prometheus to Grafana Agent Flow
 menuTitle: Migrate from Prometheus
 title: Migrate from Prometheus to Grafana Agent Flow
 weight: 320
+refs:
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  river:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language//
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language//
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  debuggingui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
+  convert:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/
 ---
 
 # Migrate from Prometheus to {{% param "PRODUCT_NAME" %}}
@@ -22,23 +68,23 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [prometheus.scrape][]
-* [prometheus.remote_write][]
+* [prometheus.scrape](ref:prometheus.scrape)
+* [prometheus.remote_write](ref:prometheus.remote_write)
 
 ## Before you begin
 
 * You must have an existing Prometheus configuration.
 * You must have a set of Prometheus applications ready to push telemetry data to {{< param "PRODUCT_NAME" >}}.
-* You must be familiar with the concept of [Components][] in {{< param "PRODUCT_NAME" >}}.
+* You must be familiar with the concept of [Components](ref:components) in {{< param "PRODUCT_NAME" >}}.
 
 ## Convert a Prometheus configuration
 
-To fully migrate your configuration from [Prometheus] to {{< param "PRODUCT_NAME" >}},
+To fully migrate your configuration from[Prometheus][] to {{< param "PRODUCT_NAME" >}},
 you must convert your Prometheus configuration into a {{< param "PRODUCT_NAME" >}} configuration.
 This conversion will enable you to take full advantage of the many
 additional features available in {{< param "PRODUCT_NAME" >}}.
 
-> In this task, we will use the [convert][] CLI command to output a flow
+> In this task, we will use the [convert](ref:convert) CLI command to output a flow
 > configuration from a Prometheus configuration.
 
 1. Open a terminal window and run the following command:
@@ -59,7 +105,7 @@ additional features available in {{< param "PRODUCT_NAME" >}}.
       * `INPUT_CONFIG_PATH`: The full path to the Prometheus configuration.
       * `OUTPUT_CONFIG_PATH`: The full path to output the {{< param "PRODUCT_NAME" >}} configuration.
 
-1. [Start][] {{< param "PRODUCT_NAME" >}} using the new flow configuration from `OUTPUT_CONFIG_PATH`:
+1. [Start](ref:start) {{< param "PRODUCT_NAME" >}} using the new flow configuration from `OUTPUT_CONFIG_PATH`:
 
 ### Debugging
 
@@ -116,10 +162,10 @@ If you’re not ready to completely switch to a flow configuration, you can run 
 The `--config.format=prometheus` flag tells {{< param "PRODUCT_ROOT_NAME" >}} to convert your Prometheus configuration to a {{< param "PRODUCT_NAME" >}} configuration and load it directly without saving the new configuration.
 This allows you to try {{< param "PRODUCT_NAME" >}} without modifying your existing Prometheus configuration infrastructure.
 
-> In this task, we will use the [run][] CLI command to run {{< param "PRODUCT_NAME" >}}
+> In this task, we will use the [run](ref:run) CLI command to run {{< param "PRODUCT_NAME" >}}
 > using a Prometheus configuration.
 
-[Start][] {{< param "PRODUCT_NAME" >}} and include the command line flag
+[Start](ref:start) {{< param "PRODUCT_NAME" >}} and include the command line flag
    `--config.format=prometheus`. Your configuration file must be a valid
    Prometheus configuration file rather than a {{< param "PRODUCT_NAME" >}} configuration file.
 
@@ -128,7 +174,7 @@ This allows you to try {{< param "PRODUCT_NAME" >}} without modifying your exist
 1. You can follow the convert CLI command [debugging][] instructions to
    generate a diagnostic report.
 
-1. Refer to the {{< param "PRODUCT_NAME" >}} [Debugging][DebuggingUI] for more information about a running {{< param "PRODUCT_NAME" >}}.
+1. Refer to the {{< param "PRODUCT_NAME" >}} [Debugging](ref:debuggingui) for more information about a running {{< param "PRODUCT_NAME" >}}.
 
 1. If your Prometheus configuration can't be converted and
     loaded directly into {{< param "PRODUCT_NAME" >}}, diagnostic information
@@ -165,7 +211,7 @@ remote_write:
       password: PASSWORD
 ```
 
-The convert command takes the YAML file as input and outputs a [River][] file.
+The convert command takes the YAML file as input and outputs a [River](ref:river) file.
 
 {{< code >}}
 
@@ -231,28 +277,8 @@ Furthermore, we recommend that you review the following checklist:
 * Metamonitoring metrics exposed by {{< param "PRODUCT_NAME" >}} usually match Prometheus metamonitoring metrics but will use a different name.
   Make sure that you use the new metric names, for example, in your alerts and dashboards queries.
 * The logs produced by {{< param "PRODUCT_NAME" >}} differ from those produced by Prometheus.
-* {{< param "PRODUCT_ROOT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI][].
+* {{< param "PRODUCT_ROOT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI](ref:ui).
 
 [Prometheus]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/
 [debugging]: #debugging
 
-{{% docs/reference %}}
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
-[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md"
-[DebuggingUI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
-[DebuggingUI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md"
-[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/_index.md"
-[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/_index.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-promtail.md
+++ b/docs/sources/flow/getting-started/migrating-from-promtail.md
@@ -9,6 +9,57 @@ description: Learn how to migrate from Promtail to Grafana Agent Flow
 menuTitle: Migrate from Promtail
 title: Migrate from Promtail to Grafana Agent Flow
 weight: 330
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
+  debuggingui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/
+  loki.source.file:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/
+  convert:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert/
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  river:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language//
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language//
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  local.file_match:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match/
+  loki.write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write/
 ---
 
 # Migrate from Promtail to {{% param "PRODUCT_NAME" %}}
@@ -23,23 +74,23 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [local.file_match][]
-* [loki.source.file][]
-* [loki.write][]
+* [local.file_match](ref:local.file_match)
+* [loki.source.file](ref:loki.source.file)
+* [loki.write](ref:loki.write)
 
 ## Before you begin
 
 * You must have an existing Promtail configuration.
-* You must be familiar with the concept of [Components][] in {{< param "PRODUCT_NAME" >}}.
+* You must be familiar with the concept of [Components](ref:components) in {{< param "PRODUCT_NAME" >}}.
 
 ## Convert a Promtail configuration
 
-To fully migrate from [Promtail] to {{< param "PRODUCT_NAME" >}}, you must convert
+To fully migrate from[Promtail][] to {{< param "PRODUCT_NAME" >}}, you must convert
 your Promtail configuration into a {{< param "PRODUCT_NAME" >}} configuration. This
 conversion will enable you to take full advantage of the many additional
 features available in {{< param "PRODUCT_NAME" >}}.
 
-> In this task, we will use the [convert][] CLI command to output a flow
+> In this task, we will use the [convert](ref:convert) CLI command to output a flow
 > configuration from a Promtail configuration.
 
 1. Open a terminal window and run the following command:
@@ -61,7 +112,7 @@ features available in {{< param "PRODUCT_NAME" >}}.
     * `INPUT_CONFIG_PATH`: The full path to the Promtail configuration.
     * `OUTPUT_CONFIG_PATH`: The full path to output the flow configuration.
 
-1. [Start][] {{< param "PRODUCT_NAME" >}} using the new flow configuration
+1. [Start](ref:start) {{< param "PRODUCT_NAME" >}} using the new flow configuration
    from `OUTPUT_CONFIG_PATH`:
 
 ### Debugging
@@ -121,9 +172,9 @@ configuration to {{< param "PRODUCT_NAME" >}} and load it directly without savin
 configuration. This allows you to try {{< param "PRODUCT_NAME" >}} without modifying your existing
 Promtail configuration infrastructure.
 
-> In this task, we will use the [run][] CLI command to run {{< param "PRODUCT_NAME" >}} using a Promtail configuration.
+> In this task, we will use the [run](ref:run) CLI command to run {{< param "PRODUCT_NAME" >}} using a Promtail configuration.
 
-[Start][] {{< param "PRODUCT_NAME" >}} and include the command line flag
+[Start](ref:start) {{< param "PRODUCT_NAME" >}} and include the command line flag
 `--config.format=promtail`. Your configuration file must be a valid Promtail
 configuration file rather than a Flow mode configuration file.
 
@@ -132,7 +183,7 @@ configuration file rather than a Flow mode configuration file.
 1. You can follow the convert CLI command [debugging][] instructions to generate
    a diagnostic report.
 
-1. Refer to the {{< param "PRODUCT_NAME" >}}  [Debugging][DebuggingUI] for more information about
+1. Refer to the {{< param "PRODUCT_NAME" >}}  [Debugging](ref:debuggingui) for more information about
    running {{< param "PRODUCT_NAME" >}}.
 
 1. If your Promtail configuration can't be converted and loaded directly into
@@ -164,7 +215,7 @@ scrape_configs:
           __path__: /var/log/*.log
 ```
 
-The convert command takes the YAML file as input and outputs a [River][] file.
+The convert command takes the YAML file as input and outputs a [River](ref:river) file.
 
 {{< code >}}
 
@@ -218,7 +269,7 @@ Furthermore, we recommend that you review the following checklist:
   whether [expanded in the config file][] itself or consumed directly by
   Promtail, such as `JAEGER_AGENT_HOST`.
 * In {{< param "PRODUCT_NAME" >}}, the positions file is saved at a different location.
-  Refer to the [loki.source.file][] documentation for more details. Check if you have any existing
+  Refer to the [loki.source.file](ref:loki.source.file) documentation for more details. Check if you have any existing
   setup, for example, a Kubernetes Persistent Volume, that you must update to use the new
   positions file path.
 * Metamonitoring metrics exposed by the Flow Mode usually match Promtail
@@ -226,32 +277,10 @@ Furthermore, we recommend that you review the following checklist:
   use the new metric names, for example, in your alerts and dashboards queries.
 * Note that the logs produced by {{< param "PRODUCT_NAME" >}} will differ from those
   produced by Promtail.
-* Note that {{< param "PRODUCT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI][], which differs
+* Note that {{< param "PRODUCT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI](ref:ui), which differs
   from Promtail's Web UI.
 
 [Promtail]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/
 [debugging]: #debugging
 [expanded in the config file]: https://www.grafana.com/docs/loki/<LOKI_VERSION>/clients/promtail/configuration/#use-environment-variables-in-the-configuration
 
-{{% docs/reference %}}
-[local.file_match]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match.md"
-[local.file_match]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match.md"
-[loki.source.file]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file.md"
-[loki.source.file]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file.md"
-[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
-[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
-[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md"
-[DebuggingUI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
-[DebuggingUI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md"
-[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/_index.md"
-[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/_index.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/migrating-from-static.md
+++ b/docs/sources/flow/getting-started/migrating-from-static.md
@@ -9,11 +9,120 @@ description: Learn how to migrate your configuration from Grafana Agent Static t
 menuTitle: Migrate from Static to Flow
 title: Migrate Grafana Agent Static to Grafana Agent Flow
 weight: 340
+refs:
+  logs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/logs-config/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/logs-config/
+  static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/
+  prometheus-limitations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-prometheus/#limitations
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-prometheus/#limitations
+  agent-management:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/agent-management/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/agent-management/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/metrics-config/
+  loki.process:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.process/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.process/
+  integrations-next:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next//
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  loki.write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write/
+  local.file_match:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match/
+  traces:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/traces-config/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/traces-config/
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  promtail-limitations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail/#limitations
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-promtail/#limitations
+  river:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  env:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/stdlib/env/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/stdlib/env/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
+  debuggingui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/
+  loki.source.file:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/
+  convert:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert/
 ---
 
 # Migrate from {{% param "PRODUCT_ROOT_NAME" %}} Static to {{% param "PRODUCT_NAME" %}}
 
-The built-in {{< param "PRODUCT_ROOT_NAME" >}} convert command can migrate your [Static][] configuration to a {{< param "PRODUCT_NAME" >}} configuration.
+The built-in {{< param "PRODUCT_ROOT_NAME" >}} convert command can migrate your [Static](ref:static) configuration to a {{< param "PRODUCT_NAME" >}} configuration.
 
 This topic describes how to:
 
@@ -22,26 +131,26 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [prometheus.scrape][]
-* [prometheus.remote_write][]
-* [local.file_match][]
-* [loki.process][]
-* [loki.source.file][]
-* [loki.write][]
+* [prometheus.scrape](ref:prometheus.scrape)
+* [prometheus.remote_write](ref:prometheus.remote_write)
+* [local.file_match](ref:local.file_match)
+* [loki.process](ref:loki.process)
+* [loki.source.file](ref:loki.source.file)
+* [loki.write](ref:loki.write)
 
 ## Before you begin
 
 * You must have an existing Grafana Agent Static configuration.
-* You must be familiar with the [Components][] concept in {{< param "PRODUCT_NAME" >}}.
+* You must be familiar with the [Components](ref:components) concept in {{< param "PRODUCT_NAME" >}}.
 
 ## Convert a Grafana Agent Static configuration
 
-To fully migrate Grafana Agent [Static][] to {{< param "PRODUCT_NAME" >}}, you must convert
+To fully migrate Grafana Agent [Static](ref:static) to {{< param "PRODUCT_NAME" >}}, you must convert
 your Static configuration into a {{< param "PRODUCT_NAME" >}} configuration.
 This conversion will enable you to take full advantage of the many additional
 features available in {{< param "PRODUCT_NAME" >}}.
 
-> In this task, we will use the [convert][] CLI command to output a {{< param "PRODUCT_NAME" >}}
+> In this task, we will use the [convert](ref:convert) CLI command to output a {{< param "PRODUCT_NAME" >}}
 > configuration from a Static configuration.
 
 1. Open a terminal window and run the following command:
@@ -59,21 +168,21 @@ features available in {{< param "PRODUCT_NAME" >}}.
    {{< /code >}}
 
    Replace the following:
-    * `INPUT_CONFIG_PATH`: The full path to the [Static][] configuration.
+    * `INPUT_CONFIG_PATH`: The full path to the [Static](ref:static) configuration.
     * `OUTPUT_CONFIG_PATH`: The full path to output the {{< param "PRODUCT_NAME" >}} configuration.
 
-1. [Start][] {{< param "PRODUCT_NAME" >}} using the new {{< param "PRODUCT_NAME" >}} configuration
+1. [Start](ref:start) {{< param "PRODUCT_NAME" >}} using the new {{< param "PRODUCT_NAME" >}} configuration
    from `OUTPUT_CONFIG_PATH`:
 
 ### Debugging
 
-1. If the convert command cannot convert a [Static] configuration, diagnostic
+1. If the convert command cannot convert a[Static](ref:static) configuration, diagnostic
    information is sent to `stderr`. You can use the `--bypass-errors` flag to
    bypass any non-critical issues and output the {{< param "PRODUCT_NAME" >}} configuration
    using a best-effort conversion.
 
    {{% admonition type="caution" %}}
-   If you bypass the errors, the behavior of the converted configuration may not match the original [Static] configuration. Make sure you fully test the converted configuration before using it in a production environment.
+   If you bypass the errors, the behavior of the converted configuration may not match the original[Static](ref:static) configuration. Make sure you fully test the converted configuration before using it in a production environment.
    {{% /admonition %}}
 
    {{< code >}}
@@ -115,15 +224,15 @@ features available in {{< param "PRODUCT_NAME" >}}.
 
 If you’re not ready to completely switch to a {{< param "PRODUCT_NAME" >}} configuration, you can run
 {{< param "PRODUCT_ROOT_NAME" >}} using your existing Grafana Agent Static configuration.
-The `--config.format=static` flag tells {{< param "PRODUCT_ROOT_NAME" >}} to convert your [Static]
+The `--config.format=static` flag tells {{< param "PRODUCT_ROOT_NAME" >}} to convert your[Static](ref:static)
 configuration to {{< param "PRODUCT_NAME" >}} and load it directly without saving the new
 configuration. This allows you to try {{< param "PRODUCT_NAME" >}} without modifying your existing
 Grafana Agent Static configuration infrastructure.
 
-> In this task, we will use the [run][] CLI command to run {{< param "PRODUCT_NAME" >}} using a Static configuration.
+> In this task, we will use the [run](ref:run) CLI command to run {{< param "PRODUCT_NAME" >}} using a Static configuration.
 
-[Start][] {{< param "PRODUCT_NAME" >}} and include the command line flag
-`--config.format=static`. Your configuration file must be a valid [Static]
+[Start](ref:start) {{< param "PRODUCT_NAME" >}} and include the command line flag
+`--config.format=static`. Your configuration file must be a valid[Static](ref:static)
 configuration file.
 
 ### Debugging
@@ -131,10 +240,10 @@ configuration file.
 1. You can follow the convert CLI command [debugging][] instructions to generate
    a diagnostic report.
 
-1. Refer to the {{< param "PRODUCT_NAME" >}} [DebuggingUI][] for more information about
+1. Refer to the {{< param "PRODUCT_NAME" >}} [DebuggingUI](ref:debuggingui) for more information about
    running {{< param "PRODUCT_NAME" >}}.
 
-1. If your [Static] configuration can't be converted and loaded directly into
+1. If your[Static](ref:static) configuration can't be converted and loaded directly into
    {{< param "PRODUCT_NAME" >}}, diagnostic information is sent to `stderr`. You can use the `
    --config.bypass-conversion-errors` flag with `--config.format=static` to bypass any
    non-critical issues and start {{< param "PRODUCT_NAME" >}}.
@@ -145,9 +254,9 @@ configuration file.
 
 ## Example
 
-This example demonstrates converting a [Static] configuration file to a {{< param "PRODUCT_NAME" >}} configuration file.
+This example demonstrates converting a[Static](ref:static) configuration file to a {{< param "PRODUCT_NAME" >}} configuration file.
 
-The following [Static] configuration file provides the input for the conversion:
+The following[Static](ref:static) configuration file provides the input for the conversion:
 
 ```yaml
 server:
@@ -203,7 +312,7 @@ logs:
         - url: https://USER_ID:API_KEY@logs-prod3.grafana.net/loki/api/v1/push
 ```
 
-The convert command takes the YAML file as input and outputs a [River][] file.
+The convert command takes the YAML file as input and outputs a [River](ref:river) file.
 
 {{< code >}}
 
@@ -305,62 +414,16 @@ before starting to use it in a production environment.
 
 Furthermore, we recommend that you review the following checklist:
 
-* The following configuration options aren't available for conversion to {{< param "PRODUCT_NAME" >}}: [Integrations next][], [Traces][], and [Agent Management][].
+* The following configuration options aren't available for conversion to {{< param "PRODUCT_NAME" >}}: [Integrations next](ref:integrations-next), [Traces](ref:traces), and [Agent Management](ref:agent-management).
   Any additional unsupported features are returned as errors during conversion.
 * There is no gRPC server to configure for {{< param "PRODUCT_NAME" >}}, as any non-default configuration will show as unsupported during the conversion.
 * Check if you are using any extra command line arguments with Static that aren't present in your configuration file. For example, `-server.http.address`.
-* Check if you are using any environment variables in your [Static][] configuration.
-  These will be evaluated during conversion and you may want to replace them with the {{< param "PRODUCT_NAME" >}} Standard library [env][] function after conversion.
-* Review additional [Prometheus Limitations][] for limitations specific to your [Metrics][] configuration.
-* Review additional [Promtail Limitations][] for limitations specific to your [Logs][] configuration.
+* Check if you are using any environment variables in your [Static](ref:static) configuration.
+  These will be evaluated during conversion and you may want to replace them with the {{< param "PRODUCT_NAME" >}} Standard library [env](ref:env) function after conversion.
+* Review additional [Prometheus Limitations](ref:prometheus-limitations) for limitations specific to your [Metrics](ref:metrics) configuration.
+* Review additional [Promtail Limitations](ref:promtail-limitations) for limitations specific to your [Logs](ref:logs) configuration.
 * The logs produced by {{< param "PRODUCT_NAME" >}} mode will differ from those produced by Static.
-* {{< param "PRODUCT_ROOT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI][].
+* {{< param "PRODUCT_ROOT_NAME" >}} exposes the {{< param "PRODUCT_NAME" >}} [UI](ref:ui).
 
 [debugging]: #debugging
 
-{{% docs/reference %}}
-[Static]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static"
-[Static]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static"
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-[local.file_match]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/local.file_match.md"
-[local.file_match]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/local.file_match.md"
-[loki.process]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.process.md"
-[loki.process]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.process.md"
-[loki.source.file]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.source.file.md"
-[loki.source.file]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.source.file.md"
-[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
-[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[convert]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/convert.md"
-[convert]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/convert.md"
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md"
-[DebuggingUI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md"
-[DebuggingUI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md"
-[River]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/"
-[River]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/"
-[Integrations next]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/_index.md"
-[Integrations next]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/traces-config.md
-[Traces]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/traces-config.md"
-[Traces]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/traces-config.md"
-[Agent Management]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/agent-management.md"
-[Agent Management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/agent-management.md"
-[env]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/stdlib/env.md"
-[env]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/stdlib/env.md"
-[Prometheus Limitations]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-prometheus.md#limitations"
-[Prometheus Limitations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-prometheus.md#limitations"
-[Promtail Limitations]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/migrating-from-promtail.md#limitations"
-[Promtail Limitations]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/migrating-from-promtail.md#limitations"
-[Metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config.md"
-[Metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/metrics-config.md"
-[Logs]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/static/configuration/logs-config.md"
-[Logs]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/logs-config.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
+++ b/docs/sources/flow/getting-started/opentelemetry-to-lgtm-stack.md
@@ -9,6 +9,57 @@ description: Learn how to collect OpenTelemetry data and forward it to the Grafa
   stack
 title: OpenTelemetry to Grafana stack
 weight: 350
+refs:
+  otelcol.exporter.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp/
+  otelcol.auth.basic:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  otelcol.processor.batch:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  collect-open-telemetry-data:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-opentelemetry-data/
+  otelcol.exporter.prometheus:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.prometheus/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.prometheus/
+  otelcol.receiver.otlp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp/
+  loki.write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write/
+  otelcol.exporter.loki:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.loki/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.loki/
 ---
 
 # OpenTelemetry to Grafana stack
@@ -23,14 +74,14 @@ This topic describes how to:
 
 ## Components used in this topic
 
-* [loki.write][]
-* [otelcol.auth.basic][]
-* [otelcol.exporter.loki][]
-* [otelcol.exporter.otlp][]
-* [otelcol.exporter.prometheus][]
-* [otelcol.processor.batch][]
-* [otelcol.receiver.otlp][]
-* [prometheus.remote_write][]
+* [loki.write](ref:loki.write)
+* [otelcol.auth.basic](ref:otelcol.auth.basic)
+* [otelcol.exporter.loki](ref:otelcol.exporter.loki)
+* [otelcol.exporter.otlp](ref:otelcol.exporter.otlp)
+* [otelcol.exporter.prometheus](ref:otelcol.exporter.prometheus)
+* [otelcol.processor.batch](ref:otelcol.processor.batch)
+* [otelcol.receiver.otlp](ref:otelcol.receiver.otlp)
+* [prometheus.remote_write](ref:prometheus.remote_write)
 
 ## Before you begin
 
@@ -39,8 +90,8 @@ This topic describes how to:
 * Have a set of OpenTelemetry applications ready to push telemetry data to
   {{< param "PRODUCT_NAME" >}}.
 * Identify where {{< param "PRODUCT_NAME" >}} will write received telemetry data.
-* Be familiar with the concept of [Components][] in {{< param "PRODUCT_NAME" >}}.
-* Complete the [Collect open telemetry data][] getting started guide. You will pick up from where that guide ended.
+* Be familiar with the concept of [Components](ref:components) in {{< param "PRODUCT_NAME" >}}.
+* Complete the [Collect open telemetry data](ref:collect-open-telemetry-data) getting started guide. You will pick up from where that guide ended.
 
 ## The pipeline
 
@@ -93,7 +144,7 @@ Traces: OTel → batch processor → OTel exporter
 ```
 ## Grafana Loki
 
-[Grafana Loki][] is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. Similar to Prometheus, to send from OTLP to Loki, we will do a passthrough from the [otelcol.exporter.loki] component to [loki.write] component.
+[Grafana Loki][] is a horizontally scalable, highly available, multi-tenant log aggregation system inspired by Prometheus. Similar to Prometheus, to send from OTLP to Loki, we will do a passthrough from the[otelcol.exporter.loki](ref:otelcol.exporter.loki) component to[loki.write](ref:loki.write) component.
 
 ```river
 otelcol.exporter.loki "default" {
@@ -106,7 +157,7 @@ loki.write "default" {
 }
 ```
 
-To use Loki with basic-auth, which is required with Grafana Cloud Loki, you must configure the [loki.write][] component. You can get the Loki configuration from the Loki **Details** page in the [Grafana Cloud Portal][]:
+To use Loki with basic-auth, which is required with Grafana Cloud Loki, you must configure the [loki.write](ref:loki.write) component. You can get the Loki configuration from the Loki **Details** page in the [Grafana Cloud Portal][]:
 
 ![](../../../assets/getting-started/loki-config.png)
 
@@ -139,7 +190,7 @@ otelcol.exporter.otlp "default" {
 }
 ```
 
-To use Tempo with basic-auth, which is required with Grafana Cloud Tempo, you must use the [otelcol.auth.basic][] component. You can get the Tempo configuration from the Tempo **Details** page in the [Grafana Cloud Portal][]:
+To use Tempo with basic-auth, which is required with Grafana Cloud Tempo, you must use the [otelcol.auth.basic](ref:otelcol.auth.basic) component. You can get the Tempo configuration from the Tempo **Details** page in the [Grafana Cloud Portal][]:
 
 ![](../../../assets/getting-started/tempo-config.png)
 
@@ -159,7 +210,7 @@ otelcol.auth.basic "grafana_cloud_tempo" {
 
 ## Grafana Mimir or Prometheus Remote Write
 
-[Prometheus Remote Write][] is a popular metrics transmission protocol supported by most metrics systems, including [Grafana Mimir][] and Grafana Cloud. To send from OTLP to Prometheus, we do a passthrough from the [otelcol.exporter.prometheus][] to the [prometheus.remote_write][] component. The Prometheus remote write component in {{< param "PRODUCT_NAME" >}} is a robust protocol implementation, including a Write Ahead Log (WAL) for resiliency.
+[Prometheus Remote Write][] is a popular metrics transmission protocol supported by most metrics systems, including [Grafana Mimir][] and Grafana Cloud. To send from OTLP to Prometheus, we do a passthrough from the [otelcol.exporter.prometheus](ref:otelcol.exporter.prometheus) to the [prometheus.remote_write](ref:prometheus.remote_write) component. The Prometheus remote write component in {{< param "PRODUCT_NAME" >}} is a robust protocol implementation, including a Write Ahead Log (WAL) for resiliency.
 
 ```river
 otelcol.exporter.prometheus "default" {
@@ -173,7 +224,7 @@ prometheus.remote_write "default" {
 }
 ```
 
-To use Prometheus with basic-auth, which is required with Grafana Cloud Prometheus, you must configure the [prometheus.remote_write][] component. You can get the Prometheus configuration from the Prometheus **Details** page in the [Grafana Cloud Portal][]:
+To use Prometheus with basic-auth, which is required with Grafana Cloud Prometheus, you must configure the [prometheus.remote_write](ref:prometheus.remote_write) component. You can get the Prometheus configuration from the Prometheus **Details** page in the [Grafana Cloud Portal][]:
 
 ![](../../../assets/getting-started/prometheus-config.png)
 
@@ -309,25 +360,3 @@ You can now check the pipeline graphically by visiting http://localhost:12345/gr
 [Prometheus Remote Write]: https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage
 [Grafana Mimir]: https://grafana.com/oss/mimir/
 
-{{% docs/reference %}}
-[Collect open telemetry data]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/getting-started/collect-opentelemetry-data.md"
-[Collect open telemetry data]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/getting-started/collect-opentelemetry-data.md"
-[Components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[Components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[loki.write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/loki.write.md"
-[loki.write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/loki.write.md"
-[otelcol.auth.basic]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.auth.basic]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.auth.basic.md"
-[otelcol.exporter.loki]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.loki.md"
-[otelcol.exporter.loki]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.loki.md"
-[otelcol.exporter.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.otlp.md"
-[otelcol.exporter.prometheus]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.exporter.prometheus.md"
-[otelcol.exporter.prometheus]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.exporter.prometheus.md"
-[otelcol.processor.batch]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.processor.batch]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.processor.batch.md"
-[otelcol.receiver.otlp]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/otelcol.receiver.otlp.md"
-[otelcol.receiver.otlp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/otelcol.receiver.otlp.md"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/monitoring/component_metrics.md
+++ b/docs/sources/flow/monitoring/component_metrics.md
@@ -9,11 +9,27 @@ canonical: https://grafana.com/docs/agent/latest/flow/monitoring/component_metri
 description: Learn about component metrics
 title: Component metrics
 weight: 200
+refs:
+  grafana-agent-run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  components:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  reference-documentation:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/
 ---
 
 # Component metrics
 
-{{< param "PRODUCT_NAME" >}} [components][] may optionally expose Prometheus metrics
+{{< param "PRODUCT_NAME" >}} [components](ref:components) may optionally expose Prometheus metrics
 which can be used to investigate the behavior of that component. These
 component-specific metrics are only generated when an instance of that
 component is running.
@@ -34,15 +50,7 @@ component ID generating those metrics. For example, component-specific metrics
 for a `prometheus.remote_write` component labeled `production` will have a
 `component_id` label with the value `prometheus.remote_write.production`.
 
-The [reference documentation][] for each component will describe the list of
+The [reference documentation](ref:reference-documentation) for each component will describe the list of
 component-specific metrics that component exposes. Not all components will
 expose metrics.
 
-{{% docs/reference %}}
-[components]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components.md"
-[components]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components.md"
-[grafana-agent run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[grafana-agent run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[reference documentation]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components"
-[reference documentation]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components"
-{{% /docs/reference %}}

--- a/docs/sources/flow/monitoring/controller_metrics.md
+++ b/docs/sources/flow/monitoring/controller_metrics.md
@@ -9,11 +9,22 @@ canonical: https://grafana.com/docs/agent/latest/flow/monitoring/controller_metr
 description: Learn about controller metrics
 title: Controller metrics
 weight: 100
+refs:
+  grafana-agent-run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  component-controller:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller/
 ---
 
 # Controller metrics
 
-The {{< param "PRODUCT_NAME" >}} [component controller][] exposes Prometheus metrics
+The {{< param "PRODUCT_NAME" >}} [component controller](ref:component-controller) exposes Prometheus metrics
 which can be used to investigate the controller state.
 
 Metrics for the controller are exposed at the `/metrics` HTTP endpoint of the
@@ -40,9 +51,3 @@ The controller exposes the following metrics:
 * `agent_component_evaluation_queue_size` (Gauge): The current number of
   component evaluations waiting to be performed.
 
-{{% docs/reference %}}
-[component controller]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/component_controller.md"
-[component controller]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/component_controller.md"
-[grafana-agent run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[grafana-agent run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/monitoring/debugging.md
+++ b/docs/sources/flow/monitoring/debugging.md
@@ -8,6 +8,32 @@ canonical: https://grafana.com/docs/agent/latest/flow/monitoring/debugging/
 description: Learn about debugging
 title: Debugging
 weight: 300
+refs:
+  clustering:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/clustering/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/clustering/
+  logging:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/logging/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/logging/
+  grafana-agent-run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  secret:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values/#secrets.md
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values/#secrets.md
+  install:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/install/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/install/
 ---
 
 # Debugging
@@ -28,7 +54,7 @@ server, which defaults to listening at `http://localhost:12345`.
 > prevents other machines on the network from being able to view the UI.
 >
 > To expose the UI to other machines on the network on non-containerized
-> platforms, refer to the documentation for how you [installed][install]
+> platforms, refer to the documentation for how you [installed](ref:install)
 > {{< param "PRODUCT_NAME" >}}.
 >
 > If you are running a custom installation of {{< param "PRODUCT_NAME" >}}, refer to the
@@ -67,7 +93,7 @@ The component detail page shows the following information for each component:
 * The current exports for the component.
 * The current debug info for the component (if the component has debug info).
 
-> Values marked as a [secret][] are obfuscated and will display as the text
+> Values marked as a [secret](ref:secret) are obfuscated and will display as the text
 > `(secret)`.
 
 ### Clustering page
@@ -94,16 +120,16 @@ To debug using the UI:
 Logs may also help debug issues with {{< param "PRODUCT_NAME" >}}.
 
 To reduce logging noise, many components hide debugging info behind debug-level
-log lines. It is recommended that you configure the [`logging` block][logging]
+log lines. It is recommended that you configure the [`logging` block](ref:logging)
 to show debug-level log lines when debugging issues with {{< param "PRODUCT_NAME" >}}.
 
 The location of {{< param "PRODUCT_NAME" >}} logs is different based on how it is deployed.
-Refer to the [`logging` block][logging] page to see how to find logs for your
+Refer to the [`logging` block](ref:logging) page to see how to find logs for your
 system.
 
 ## Debugging clustering issues
 
-To debug issues when using [clustering][], check for the following symptoms.
+To debug issues when using [clustering](ref:clustering), check for the following symptoms.
 
 - **Cluster not converging**: The cluster peers are not converging on the same
   view of their peers' status. This is most likely due to network connectivity
@@ -126,16 +152,4 @@ down and set its state to Terminating, but it has not completely gone away. Chec
 the clustering page to view the state of the peers and verify that the
 terminating {{< param "PRODUCT_ROOT_NAME" >}} has been shut down.
 
-{{% docs/reference %}}
-[logging]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/config-blocks/logging.md"
-[logging]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/config-blocks/logging.md"
-[clustering]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/clustering.md"
-[clustering]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/clustering.md"
-[install]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/install"
-[install]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/install"
-[secret]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/config-language/expressions/types_and_values.md#secrets.md"
-[secret]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/config-language/expressions/types_and_values.md#secrets.md"
-[grafana-agent run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[grafana-agent run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-{{% /docs/reference %}}
 

--- a/docs/sources/flow/setup/configure/configure-linux.md
+++ b/docs/sources/flow/setup/configure/configure-linux.md
@@ -9,6 +9,17 @@ description: Learn how to configure Grafana Agent Flow on Linux
 menuTitle: Linux
 title: Configure Grafana Agent Flow on Linux
 weight: 300
+refs:
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Configure {{% param "PRODUCT_NAME" %}} on Linux
@@ -41,7 +52,7 @@ To change the configuration file used by the service, perform the following step
 
 ## Pass additional command-line flags
 
-By default, the {{< param "PRODUCT_NAME" >}} service launches with the [run][]
+By default, the {{< param "PRODUCT_NAME" >}} service launches with the [run](ref:run)
 command, passing the following flags:
 
 * `--storage.path=/var/lib/grafana-agent-flow`
@@ -64,13 +75,13 @@ the following steps:
    ```
 
 To see the list of valid command-line flags that can be passed to the service,
-refer to the documentation for the [run][] command.
+refer to the documentation for the [run](ref:run) command.
 
 ## Expose the UI to other machines
 
 By default, {{< param "PRODUCT_NAME" >}} listens on the local network for its HTTP
 server. This prevents other machines on the network from being able to access
-the [UI for debugging][UI].
+the [UI for debugging](ref:ui).
 
 To expose the UI to other machines, complete the following steps:
 
@@ -90,9 +101,3 @@ To expose the UI to other machines, complete the following steps:
 
        To listen on all interfaces, replace `LISTEN_ADDR` with `0.0.0.0`.
 
-{{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/configure/configure-macos.md
+++ b/docs/sources/flow/setup/configure/configure-macos.md
@@ -9,6 +9,12 @@ description: Learn how to configure Grafana Agent Flow on macOS
 menuTitle: macOS
 title: Configure Grafana Agent Flow on macOS
 weight: 400
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Configure {{% param "PRODUCT_NAME" %}} on macOS
@@ -66,7 +72,7 @@ steps:
 
 By default, {{< param "PRODUCT_NAME" >}} listens on the local network for its HTTP
 server. This prevents other machines on the network from being able to access
-the [UI for debugging][UI].
+the [UI for debugging](ref:ui).
 
 To expose the UI to other machines, complete the following steps:
 
@@ -81,7 +87,3 @@ To expose the UI to other machines, complete the following steps:
 
        To listen on all interfaces, replace `127.0.0.1` with `0.0.0.0`.
 
-{{% docs/reference %}}
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/configure/configure-windows.md
+++ b/docs/sources/flow/setup/configure/configure-windows.md
@@ -9,6 +9,12 @@ description: Learn how to configure Grafana Agent Flow on Windows
 menuTitle: Windows
 title: Configure Grafana Agent Flow on Windows
 weight: 500
+refs:
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Configure {{% param "PRODUCT_NAME" %}} on Windows
@@ -69,7 +75,7 @@ binary, perform the following steps:
 
 By default, {{< param "PRODUCT_NAME" >}} listens on the local network for its HTTP
 server. This prevents other machines on the network from being able to access
-the [UI for debugging][UI].
+the [UI for debugging](ref:ui).
 
 To expose the UI to other machines, complete the following steps:
 
@@ -89,8 +95,4 @@ To expose the UI to other machines, complete the following steps:
 
        To listen on all interfaces, replace `LISTEN_ADDR` with `0.0.0.0`.
 
-{{% docs/reference %}}
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}
 

--- a/docs/sources/flow/setup/install/_index.md
+++ b/docs/sources/flow/setup/install/_index.md
@@ -10,6 +10,12 @@ description: Learn how to install Grafana Agent  Flow
 menuTitle: Install Grafana Agent Flow
 title: Install Grafana Agent Flow
 weight: 50
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/data-collection/
 ---
 
 # Install {{% param "PRODUCT_NAME" %}}
@@ -31,10 +37,6 @@ Installing {{< param "PRODUCT_NAME" >}} on other operating systems is possible, 
 
 ## Data collection
 
-By default, {{< param "PRODUCT_NAME" >}} sends anonymous usage information to Grafana Labs. Refer to [data collection][] for more information
+By default, {{< param "PRODUCT_NAME" >}} sends anonymous usage information to Grafana Labs. Refer to [data collection](ref:data-collection) for more information
 about what data is collected and how you can opt-out.
 
-{{% docs/reference %}}
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/binary.md
+++ b/docs/sources/flow/setup/install/binary.md
@@ -10,6 +10,17 @@ description: Learn how to install Grafana Agent Flow as a standalone binary
 menuTitle: Standalone
 title: Install Grafana Agent  Flow as a standalone binary
 weight: 600
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#standalone-binary
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#standalone-binary
 ---
 
 # Install {{% param "PRODUCT_NAME" %}} as a standalone binary
@@ -45,9 +56,3 @@ To download {{< param "PRODUCT_NAME" >}} as a standalone binary, perform the fol
 
 {{< param "PRODUCT_NAME" >}}
 
-{{% docs/reference %}}
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#standalone-binary"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#standalone-binary"
-[Configure]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure"
-[Configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/docker.md
+++ b/docs/sources/flow/setup/install/docker.md
@@ -10,6 +10,17 @@ description: Learn how to install Grafana Agent Flow on Docker
 menuTitle: Docker
 title: Run Grafana Agent Flow in a Docker container
 weight: 100
+refs:
+  run:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/cli/run/
+  ui:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging/#grafana-agent-flow-ui
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging/#grafana-agent-flow-ui
 ---
 
 # Run {{% param "PRODUCT_NAME" %}} in a Docker container
@@ -47,10 +58,10 @@ docker run \
 Replace `CONFIG_FILE_PATH` with the path of the configuration file on your host system.
 
 You can modify the last line to change the arguments passed to the {{< param "PRODUCT_NAME" >}} binary.
-Refer to the documentation for [run][] for more information about the options available to the `run` command.
+Refer to the documentation for [run](ref:run) for more information about the options available to the `run` command.
 
 > **Note:** Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
-> If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
+> If you don't pass this argument, the [debugging UI](ref:ui) won't be available outside of the Docker container.
 
 
 ## Run a Windows Docker container
@@ -69,23 +80,17 @@ docker run \
 Replace `CONFIG_FILE_PATH` with the path of the configuration file on your host system.
 
 You can modify the last line to change the arguments passed to the {{< param "PRODUCT_NAME" >}} binary.
-Refer to the documentation for [run][] for more information about the options available to the `run` command.
+Refer to the documentation for [run](ref:run) for more information about the options available to the `run` command.
 
 
 > **Note:** Make sure you pass `--server.http.listen-addr=0.0.0.0:12345` as an argument as shown in the example above.
-> If you don't pass this argument, the [debugging UI][UI] won't be available outside of the Docker container.
+> If you don't pass this argument, the [debugging UI](ref:ui) won't be available outside of the Docker container.
 
 ## Verify
 
-To verify that {{< param "PRODUCT_NAME" >}} is running successfully, navigate to <http://localhost:12345> and make sure the {{< param "PRODUCT_NAME" >}} [UI][] loads without error.
+To verify that {{< param "PRODUCT_NAME" >}} is running successfully, navigate to <http://localhost:12345> and make sure the {{< param "PRODUCT_NAME" >}} [UI](ref:ui) loads without error.
 
 [Linux containers]: #run-a-linux-docker-container
 [Windows containers]: #run-a-windows-docker-container
 [Docker]: https://docker.io
 
-{{% docs/reference %}}
-[run]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/cli/run.md"
-[run]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/cli/run.md"
-[UI]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-[UI]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/monitoring/debugging.md#grafana-agent-flow-ui"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/kubernetes.md
+++ b/docs/sources/flow/setup/install/kubernetes.md
@@ -10,6 +10,12 @@ description: Learn how to deploy Grafana Agent Flow on Kubernetes
 menuTitle: Kubernetes
 title: Deploy Grafana Agent Flow on Kubernetes
 weight: 200
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-kubernetes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-kubernetes/
 ---
 
 # Deploy {{% param "PRODUCT_NAME" %}} on Kubernetes
@@ -58,11 +64,7 @@ For more information on the {{< param "PRODUCT_ROOT_NAME" >}} Helm chart, refer 
 
 ## Next steps
 
-- [Configure {{< param "PRODUCT_NAME" >}}][Configure]
+- [Configure {{< param "PRODUCT_NAME" >}}](ref:configure)
 
 [Helm]: https://helm.sh
 
-{{% docs/reference %}}
-[Configure]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-kubernetes.md"
-[Configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-kubernetes.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/linux.md
+++ b/docs/sources/flow/setup/install/linux.md
@@ -10,6 +10,17 @@ description: Learn how to install Grafana Agent Flow on Linux
 menuTitle: Linux
 title: Install Grafana Agent Flow on Linux
 weight: 300
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-linux/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-linux/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#linux
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#linux
 ---
 
 # Install or uninstall {{% param "PRODUCT_NAME" %}} on Linux
@@ -119,12 +130,6 @@ To uninstall {{< param "PRODUCT_NAME" >}} on Linux, run the following commands i
 
 ## Next steps
 
-- [Start {{< param "PRODUCT_NAME" >}}][Start]
-- [Configure {{< param "PRODUCT_NAME" >}}][Configure]
+- [Start {{< param "PRODUCT_NAME" >}}](ref:start)
+- [Configure {{< param "PRODUCT_NAME" >}}](ref:configure)
 
-{{% docs/reference %}}
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#linux"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#linux"
-[Configure]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-linux.md"
-[Configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-linux.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/macos.md
+++ b/docs/sources/flow/setup/install/macos.md
@@ -10,6 +10,17 @@ description: Learn how to install Grafana AgentFlow on macOS
 menuTitle: macOS
 title: Install Grafana Agent Flow on macOS
 weight: 400
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#macos
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#macos
 ---
 
 # Install {{% param "PRODUCT_NAME" %}} on macOS
@@ -66,14 +77,8 @@ brew uninstall grafana-agent-flow
 
 ## Next steps
 
-- [Start {{< param "PRODUCT_NAME" >}}][Start]
-- [Configure {{< param "PRODUCT_NAME" >}}][Configure]
+- [Start {{< param "PRODUCT_NAME" >}}](ref:start)
+- [Configure {{< param "PRODUCT_NAME" >}}](ref:configure)
 
 [Homebrew]: https://brew.sh
 
-{{% docs/reference %}}
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#macos"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#macos"
-[Configure]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos.md"
-[Configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/install/windows.md
+++ b/docs/sources/flow/setup/install/windows.md
@@ -10,6 +10,22 @@ description: Learn how to install Grafana Agent Flow on Windows
 menuTitle: Windows
 title: Install Grafana Agent Flow on Windows
 weight: 500
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/data-collection/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/start-agent/#windows
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/start-agent/#windows
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-windows/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-windows/
 ---
 
 # Install {{% param "PRODUCT_NAME" %}} on Windows
@@ -55,7 +71,7 @@ To do a silent install of {{< param "PRODUCT_NAME" >}} on Windows, perform the f
 ### Silent install options
 
 * `/CONFIG=<path>` Path to the configuration file. Default: `$INSTDIR\config.river`
-* `/DISABLEREPORTING=<yes|no>` Disable [data collection][]. Default: `no`
+* `/DISABLEREPORTING=<yes|no>` Disable [data collection](ref:data-collection). Default: `no`
 * `/DISABLEPROFILING=<yes|no>` Disable profiling endpoint. Default: `no`
 
 ## Uninstall
@@ -68,16 +84,8 @@ This includes any configuration files in the installation directory.
 
 ## Next steps
 
-- [Start {{< param "PRODUCT_NAME" >}}][Start]
-- [Configure {{< param "PRODUCT_NAME" >}}][Configure]
+- [Start {{< param "PRODUCT_NAME" >}}](ref:start)
+- [Configure {{< param "PRODUCT_NAME" >}}](ref:configure)
 
 [latest]: https://github.com/grafana/agent/releases/latest
 
-{{% docs/reference %}}
-[Start]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/start-agent.md#windows"
-[Start]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/start-agent.md#windows"
-[Configure]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-windows.md"
-[Configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-windows.md"
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/setup/start-agent.md
+++ b/docs/sources/flow/setup/start-agent.md
@@ -9,6 +9,12 @@ description: Learn how to start, restart, and stop Grafana Agent after it is ins
 menuTitle: Start Grafana Agent Flow
 title: Start, restart, and stop Grafana Agent Flow
 weight: 800
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos/#configure-the-grafana-agent-service
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos/#configure-the-grafana-agent-service
 ---
 
 # Start, restart, and stop {{% param "PRODUCT_NAME" %}}
@@ -108,7 +114,7 @@ brew services stop grafana-agent-flow
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent-flow.log` and
 `$(brew --prefix)/var/log/grafana-agent-flow.err.log`.
 
-If you followed [Configure the {{< param "PRODUCT_NAME" >}} service][Configure] and changed the path where logs are written,
+If you followed [Configure the {{< param "PRODUCT_NAME" >}} service](ref:configure) and changed the path where logs are written,
 refer to your current copy of the {{< param "PRODUCT_NAME" >}} formula to locate your log files.
 
 ## Windows
@@ -251,7 +257,3 @@ These steps assume you have a default systemd and {{< param "PRODUCT_NAME" >}} c
 
 [release]: https://github.com/grafana/agent/releases/latest
 
-{{% docs/reference %}}
-[Configure]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/setup/configure/configure-macos.md#configure-the-grafana-agent-service"
-[Configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/setup/configure/configure-macos.md#configure-the-grafana-agent-service"
-{{% /docs/reference %}}

--- a/docs/sources/flow/tutorials/chaining.md
+++ b/docs/sources/flow/tutorials/chaining.md
@@ -10,11 +10,17 @@ description: Learn how to chain Prometheus components
 menuTitle: Chain Prometheus components
 title: Chain Prometheus components
 weight: 400
+refs:
+  filtering-metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/tutorials/filtering-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/tutorials/filtering-metrics/
 ---
 
 # Chain Prometheus components
 
-This tutorial shows how to use [multiple-inputs.river][] to send data to several different locations. This tutorial uses the same base as [Filtering metrics][].
+This tutorial shows how to use [multiple-inputs.river][] to send data to several different locations. This tutorial uses the same base as [Filtering metrics](ref:filtering-metrics).
 
 A new concept introduced in Flow is chaining components together in a composable pipeline. This promotes the reusability of components while offering flexibility.
 
@@ -86,7 +92,3 @@ In `multiple-input.river` add a new `prometheus.relabel` component that adds a `
 [Grafana]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D
 [node_exporter]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22node_cpu_seconds_total%22%7D%5D
 
-{{% docs/reference %}}
-[Filtering metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tutorials/filtering-metrics.md"
-[Filtering metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tutorials/filtering-metrics.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
+++ b/docs/sources/flow/tutorials/collecting-prometheus-metrics.md
@@ -10,6 +10,32 @@ description: Learn how to collect Prometheus metrics
 menuTitle: Collect Prometheus metrics
 title: Collect Prometheus metrics
 weight: 200
+refs:
+  prometheus.scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape/
+  argument:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  export:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/components/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/components/
+  prometheus.remote_write:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write/
+  attribute:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/configuration_language/#attributes
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/concepts/configuration_language/#attributes
 ---
 
 # Collect Prometheus metrics
@@ -51,7 +77,7 @@ Click the nodes to navigate to the associated component page. There, you can vie
 
 ## Scraping component
 
-The [`prometheus.scrape`][prometheus.scrape] component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
+The [`prometheus.scrape`](ref:prometheus.scrape) component is responsible for scraping the metrics of a particular endpoint and passing them on to another component.
 
 ```river
 // prometheus.scrape is the name of the component and "default" is its label.
@@ -69,13 +95,13 @@ prometheus.scrape "default" {
 
 The `prometheus.scrape "default"` annotation indicates the name of the component, `prometheus.scrape`, and its label, `default`. All components must have a unique combination of name and if applicable label.
 
-The `targets` [attribute][] is an [argument][]. `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the {{< param "PRODUCT_NAME" >}} `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
+The `targets` [attribute](ref:attribute) is an [argument](ref:argument). `targets` is a list of labels that specify the target via the special key `__address__`. The scraper is targeting the {{< param "PRODUCT_NAME" >}} `/metrics` endpoint. Both `http` and `/metrics` are implied but can be overridden.
 
-The `forward_to` attribute is an argument that references the [export][] of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
+The `forward_to` attribute is an argument that references the [export](ref:export) of the `prometheus.remote_write.prom` component. This is where the scraper will send the metrics for further processing.
 
 ## Remote Write component
 
-The [`prometheus.remote_write`][prometheus.remote_write] component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
+The [`prometheus.remote_write`](ref:prometheus.remote_write) component is responsible for writing the metrics to a Prometheus-compatible endpoint (Mimir).
 
 ```river
 prometheus.remote_write "prom" {
@@ -96,15 +122,3 @@ To try out {{< param "PRODUCT_ROOT_NAME" >}} without using Docker:
 [Docker]: https://www.docker.com/products/docker-desktop
 [Grafana]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D
 
-{{% docs/reference %}}
-[prometheus.scrape]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.scrape.md"
-[prometheus.scrape]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.scrape.md"
-[attribute]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/configuration_language.md#attributes"
-[attribute]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/configuration_language.md#attributes"
-[argument]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components"
-[argument]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components"
-[export]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/concepts/components"
-[export]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/concepts/components"
-[prometheus.remote_write]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write.md"
-[prometheus.remote_write]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.remote_write.md"
-{{% /docs/reference %}}

--- a/docs/sources/flow/tutorials/filtering-metrics.md
+++ b/docs/sources/flow/tutorials/filtering-metrics.md
@@ -10,11 +10,22 @@ description: Learn how to filter Prometheus metrics
 menuTitle: Filter Prometheus metrics
 title: Filter Prometheus metrics
 weight: 300
+refs:
+  collecting-prometheus-metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/tutorials/collecting-prometheus-metrics/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/tutorials/collecting-prometheus-metrics/
+  prometheus.relabel:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.relabel/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.relabel/
 ---
 
 # Filter Prometheus metrics
 
-In this tutorial, you'll add a new component [prometheus.relabel][] using [relabel.river][] to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics][].
+In this tutorial, you'll add a new component [prometheus.relabel](ref:prometheus.relabel) using [relabel.river][] to filter metrics. This tutorial uses the same base as [Collecting Prometheus metrics](ref:collecting-prometheus-metrics).
 
 ## Prerequisites
 
@@ -58,9 +69,3 @@ Open the `relabel.river` file that was downloaded and change the name of the ser
 [Grafana]: http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Mimir%22,%7B%22refId%22:%22A%22,%22instant%22:true,%22range%22:true,%22exemplar%22:true,%22expr%22:%22agent_build_info%7B%7D%22%7D%5D
 [relabel.river]: https://grafana.com/docs/agent/<AGENT_VERSION>/flow/tutorials/assets/flow_configs/relabel.river
 
-{{% docs/reference %}}
-[prometheus.relabel]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.relabel.md"
-[prometheus.relabel]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/reference/components/prometheus.relabel.md"
-[Collecting Prometheus metrics]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/flow/tutorials/collecting-prometheus-metrics.md"
-[Collecting Prometheus metrics]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/flow/tutorials/collecting-prometheus-metrics.md"
-{{% /docs/reference %}}

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -10,6 +10,17 @@ description: Release notes for Grafana Agent Operator
 menuTitle: Release notes
 title: Release notes for Grafana Agent Operator
 weight: 999
+refs:
+  release-notes-static:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/release-notes/
+    - pattern: /docs/agent/
+      destination: /docs/grafana-cloud/send-data/agent/static/release-notes/
+  release-notes-flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
 ---
 
 # Release notes for Grafana Agent Operator
@@ -21,16 +32,9 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 > **Note:** These release notes are specific to the Static mode Kubernetes Operator.
 > Other release notes for the different Grafana Agent variants are contained on separate pages:
 >
-> - [Static mode release notes][release-notes-static]
-> - [Flow mode release notes][release-notes-flow]
+> - [Static mode release notes](ref:release-notes-static)
+> - [Flow mode release notes](ref:release-notes-flow)
 
-{{% docs/reference %}}
-[release-notes-static]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/release-notes"
-[release-notes-static]: "/docs/agent/ -> /docs/grafana-cloud/send-data/agent/static/release-notes"
-
-[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-{{% /docs/reference %}}
 
 ## v0.33
 

--- a/docs/sources/operator/release-notes.md
+++ b/docs/sources/operator/release-notes.md
@@ -13,14 +13,14 @@ weight: 999
 refs:
   release-notes-static:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/static/release-notes/
     - pattern: /docs/agent/
       destination: /docs/grafana-cloud/send-data/agent/static/release-notes/
   release-notes-flow:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
 ---
 
 # Release notes for Grafana Agent Operator

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -6,6 +6,22 @@ canonical: https://grafana.com/docs/agent/latest/static/
 description: Learn about Grafana Agent in static mode
 title: Static mode
 weight: 200
+refs:
+  install:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/
+    - pattern: /docs/grafana-cloud/
+      destination: ./set-up/install/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: ./configuration/
+  set-up:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/
+    - pattern: /docs/grafana-cloud/
+      destination: ./set-up/
 ---
 
 # Static mode
@@ -23,7 +39,7 @@ Static mode is composed of different _subsystems_:
   traces and forwarding them to Grafana Tempo or any OpenTelemetry-compatible
   endpoint.
 
-Static mode is [configured][configure] with a YAML file.
+Static mode is [configured](ref:configure) with a YAML file.
 
 Static mode works with:
 
@@ -34,7 +50,7 @@ Static mode works with:
 This topic helps you to think about what you're trying to accomplish and how to
 use Grafana Agent to meet your goals.
 
-You can [set up][] and [configure][] Grafana Agent in static mode manually, or
+You can [set up](ref:set-up) and [configure](ref:configure) Grafana Agent in static mode manually, or
 you can follow the common workflows described in this topic.
 
 ## Topics
@@ -67,7 +83,7 @@ Grafana Cloud integration workflows and the Kubernetes Monitoring solution are t
 
 | Topic | Description |
 |---|---|
-| [Install or uninstall Grafana Agent][install] | Install or uninstall Grafana Agent. |
+| [Install or uninstall Grafana Agent](ref:install) | Install or uninstall Grafana Agent. |
 | [Troubleshoot Cloud Integrations installation on Linux](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-linux/) | Troubleshoot common errors when executing the Grafana Agent installation script on Linux.  |
 | [Troubleshoot Cloud Integrations installation on Mac](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshoot-mac/) | Troubleshoot common errors when executing the Grafana Agent installation script on Mac.  |
 | [Troubleshoot Cloud Integrations installation on Windows](/docs/grafana-cloud/monitor-infrastructure/integrations/install-troubleshooting-windows/) | Troubleshoot common errors when executing the Grafana Agent installation script on Windows.  |
@@ -87,11 +103,3 @@ Logs are included when you [set up a Cloud integration](/docs/grafana-cloud/data
 | [Set up and use tracing](/docs/grafana-cloud/data-configuration/traces/set-up-and-use-tempo/) |  Install Grafana Agent to collect traces for use with Grafana Tempo, included with your [Grafana Cloud account](/docs/grafana-cloud/account-management/cloud-portal/). |
 | [Use Grafana Agent as a tracing pipeline](/docs/tempo/latest/configuration/grafana-agent/) | Grafana Agent can be configured to run a set of tracing pipelines to collect data from your applications and write it to Grafana Tempo. Pipelines are built using OpenTelemetry, and consist of receivers, processors, and exporters. |
 
-{{% docs/reference %}}
-[set up]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up"
-[set up]: "/docs/grafana-cloud/ -> ./set-up"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ./configuration"
-[install]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install"
-[install]: "/docs/grafana-cloud/ -> ./set-up/install"
-{{% /docs/reference %}}

--- a/docs/sources/static/_index.md
+++ b/docs/sources/static/_index.md
@@ -9,17 +9,17 @@ weight: 200
 refs:
   install:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/
     - pattern: /docs/grafana-cloud/
       destination: ./set-up/install/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: ./configuration/
   set-up:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/
     - pattern: /docs/grafana-cloud/
       destination: ./set-up/
 ---

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -11,15 +11,15 @@ weight: 400
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/metrics-config/
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/integrations/integrations-next/
 ---

--- a/docs/sources/static/api/_index.md
+++ b/docs/sources/static/api/_index.md
@@ -8,6 +8,20 @@ description: Learn about the Grafana Agent static mode API
 menuTitle: Static mode API
 title: Static mode APIs (Stable)
 weight: 400
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/metrics-config/
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/integrations/integrations-next/
 ---
 
 # Static mode APIs (Stable)
@@ -23,7 +37,7 @@ API endpoints are stable unless otherwise noted.
 
 ## Config management API (Beta)
 
-Grafana Agent exposes a configuration management REST API for managing instance configurations when it's running in [scraping service mode][scrape].
+Grafana Agent exposes a configuration management REST API for managing instance configurations when it's running in [scraping service mode](ref:scrape).
 
 {{< admonition type="note" >}}
 The scraping service mode is a requirement for the configuration management
@@ -130,7 +144,7 @@ with the same name already exists, then it will be completely overwritten.
 URL-encoded names are stored in decoded form. e.g., `hello%2Fworld` will
 represent the config named `hello/world`.
 
-The request body passed to this endpoint must match the format of [metrics_instance_config][metrics]
+The request body passed to this endpoint must match the format of [metrics_instance_config](ref:metrics)
 defined in the Configuration Reference. The name field of the configuration is
 ignored and the name in the URL takes precedence. The request body must be
 formatted as YAML.
@@ -417,7 +431,7 @@ A support bundle contains the following data:
 ## Integrations API (Experimental)
 
 > **WARNING**: This API is currently only available when the experimental
-> [integrations revamp][integrations]
+> [integrations revamp](ref:integrations)
 > is enabled. Both the revamp and this API are subject to change while they
 > are still experimental.
 
@@ -529,11 +543,3 @@ Response:
 Agent is Healthy.
 ```
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next"
-[integrations]: "/docs/grafana-cloud/ -> ../configuration/integrations/integrations-next"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -10,37 +10,37 @@ weight: 300
 refs:
   server:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/server-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/server-config/
     - pattern: /docs/grafana-cloud/
       destination: ./server-config/
   traces:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/traces-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/traces-config/
     - pattern: /docs/grafana-cloud/
       destination: ./traces-config/
   logs:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/logs-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/logs-config/
     - pattern: /docs/grafana-cloud/
       destination: ./logs-config/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/#reload-configuration-file-beta
+      destination: /docs/agent/<AGENT_VERSION>/static/api/#reload-configuration-file-beta
     - pattern: /docs/grafana-cloud/
       destination: ../api/#reload-configuration-file-beta
   integrations:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/
     - pattern: /docs/grafana-cloud/
       destination: ./integrations/
   flags:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/flags/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/flags/
     - pattern: /docs/grafana-cloud/
       destination: ./flags/
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ./metrics-config/
 ---

--- a/docs/sources/static/configuration/_index.md
+++ b/docs/sources/static/configuration/_index.md
@@ -7,6 +7,42 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/
 description: Learn how to configure Grafana Agent in static mode
 title: Configure static mode
 weight: 300
+refs:
+  server:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/server-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./server-config/
+  traces:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/traces-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./traces-config/
+  logs:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/logs-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./logs-config/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/#reload-configuration-file-beta
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/#reload-configuration-file-beta
+  integrations:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/
+    - pattern: /docs/grafana-cloud/
+      destination: ./integrations/
+  flags:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/flags/
+    - pattern: /docs/grafana-cloud/
+      destination: ./flags/
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./metrics-config/
 ---
 
 # Configure static mode
@@ -14,7 +50,7 @@ weight: 300
 The configuration of static mode is split across two places:
 
 * A YAML file
-* [Command-line flags][flags]
+* [Command-line flags](ref:flags)
 
 The YAML file is used to configure settings which are dynamic and can be
 changed at runtime. The command-line flags then configure things which cannot
@@ -22,11 +58,11 @@ change at runtime, such as the listen port for the HTTP server.
 
 This file describes the YAML configuration, which is usually in a file named `config.yaml`.
 
-- [server_config][server]
-- [metrics_config][metrics]
-- [logs_config][logs]
-- [traces_config][traces]
-- [integrations_config][integrations]
+- [server_config](ref:server)
+- [metrics_config](ref:metrics)
+- [logs_config](ref:logs)
+- [traces_config](ref:traces)
+- [integrations_config](ref:integrations)
 
 The configuration of Grafana Agent is "stable," but subject to breaking changes
 as individual features change. Breaking changes to configuration will be
@@ -79,7 +115,7 @@ which may be slightly unexpected.
 
 ## Reloading (beta)
 
-The configuration file can be reloaded at runtime. Read the [API documentation][api] for more information.
+The configuration file can be reloaded at runtime. Read the [API documentation](ref:api) for more information.
 
 This functionality is in beta, and may have issues. Please open GitHub issues
 for any problems you encounter.
@@ -141,19 +177,3 @@ The following flags will configure basic auth for requests made to HTTP/S remote
 This beta feature is subject to change in future releases.
 {{% /admonition %}}
 
-{{% docs/reference %}}
-[flags]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/flags"
-[flags]: "/docs/grafana-cloud/ -> ./flags"
-[server]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/server-config"
-[server]: "/docs/grafana-cloud/ -> ./server-config"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
-[logs]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/logs-config"
-[logs]: "/docs/grafana-cloud/ -> ./logs-config"
-[traces]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/traces-config"
-[traces]: "/docs/grafana-cloud/ -> ./traces-config"
-[integrations]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations"
-[integrations]: "/docs/grafana-cloud/ -> ./integrations"
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#reload-configuration-file-beta"
-[api]: "/docs/grafana-cloud/ -> ../api#reload-configuration-file-beta"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -11,7 +11,7 @@ weight: 50
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/
 ---

--- a/docs/sources/static/configuration/create-config-file.md
+++ b/docs/sources/static/configuration/create-config-file.md
@@ -8,6 +8,12 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/create-con
 description: Learn how to create a configuration file
 title: Create a configuration file
 weight: 50
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/
 ---
 
 # Create a configuration file
@@ -64,7 +70,7 @@ the Grafana Agent is running on. This label helps to uniquely identify the
 source of metrics if you are running multiple Grafana Agents across multiple
 machines.
 
-Full configuration options can be found in the [configuration reference][configure].
+Full configuration options can be found in the [configuration reference](ref:configure).
 
 ## Prometheus config/migrating from Prometheus
 
@@ -109,7 +115,7 @@ metrics:
 ```
 
 Like with integrations, full configuration options can be found in the
-[configuration][configure].
+[configuration](ref:configure).
 
 ## Loki Config/Migrating from Promtail
 
@@ -186,7 +192,3 @@ integrations:
     enabled: true
 ```
 
-{{% docs/reference %}}
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -10,17 +10,17 @@ weight: 100
 refs:
   revamp:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/integrations/integrations-next/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/integrations-next/
   management:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/agent-management/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/agent-management/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/agent-management/
   retrieving:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/#remote-configuration-experimental
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/#remote-configuration-experimental
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/send-data/agent/static/configuration/#remote-configuration-experimental
 ---

--- a/docs/sources/static/configuration/flags.md
+++ b/docs/sources/static/configuration/flags.md
@@ -7,6 +7,22 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/flags/
 description: Learn about command-line flags
 title: Command-line flags
 weight: 100
+refs:
+  revamp:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/integrations/integrations-next/
+  management:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/agent-management/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/agent-management/
+  retrieving:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/#remote-configuration-experimental
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/static/configuration/#remote-configuration-experimental
 ---
 
 # Command-line flags
@@ -33,10 +49,10 @@ names to enable.
 
 Valid feature names are:
 
-* `remote-configs`: Enable [retrieving][retrieving] config files over HTTP/HTTPS
-* `integrations-next`: Enable [revamp][revamp] of the integrations subsystem
+* `remote-configs`: Enable [retrieving](ref:retrieving) config files over HTTP/HTTPS
+* `integrations-next`: Enable [revamp](ref:revamp) of the integrations subsystem
 * `extra-scrape-metrics`: When enabled, additional time series  are exposed for each metrics instance scrape. See [Extra scrape metrics](https://prometheus.io/docs/prometheus/2.45/feature_flags/#extra-scrape-metrics).
-* `agent-management`: Enable support for [agent management][management].
+* `agent-management`: Enable support for [agent management](ref:management).
 
 ## Report information usage
 
@@ -146,13 +162,3 @@ YAML configuration when the `-server.http.tls-enabled` flag is used.
 
 * `-metrics.wal-directory`: Directory to store the metrics Write-Ahead Log in
 
-{{% docs/reference %}}
-[retrieving]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration#remote-configuration-experimental"
-[retrieving]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration#remote-configuration-experimental"
-
-[revamp]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/integrations/integrations-next/"
-[revamp]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/integrations/integrations-next"
-
-[management]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/agent-management"
-[management]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/static/configuration/agent-management"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -8,6 +8,12 @@ canonical: https://grafana.com/docs/agent/latest/static/configuration/metrics-co
 description: Learn about metrics_config
 title: metrics_config
 weight: 200
+refs:
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+    - pattern: /docs/grafana-cloud/
+      destination: ./scraping-service/
 ---
 
 # metrics_config
@@ -68,7 +74,7 @@ configs:
 
 ## scraping_service_config
 
-The `scraping_service` block configures the [scraping service][scrape], an operational
+The `scraping_service` block configures the [scraping service](ref:scrape), an operational
 mode where configurations are stored centrally in a KV store and a cluster of
 agents distributes discovery and scrape load between nodes.
 
@@ -346,7 +352,3 @@ remote_write:
 
 {{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT VERSION>" >}}
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ./scraping-service"
-{{% /docs/reference %}}

--- a/docs/sources/static/configuration/metrics-config.md
+++ b/docs/sources/static/configuration/metrics-config.md
@@ -11,7 +11,7 @@ weight: 200
 refs:
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
     - pattern: /docs/grafana-cloud/
       destination: ./scraping-service/
 ---
@@ -350,5 +350,5 @@ remote_write:
 
 ## Data retention
 
-{{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT VERSION>" >}}
+{{< docs/shared source="agent" lookup="/wal-data-retention.md" version="<AGENT_VERSION>" >}}
 

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -12,12 +12,12 @@ weight: 600
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ./metrics-config/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/
+      destination: /docs/agent/<AGENT_VERSION>/static/api/
     - pattern: /docs/grafana-cloud/
       destination: ../api/
 ---

--- a/docs/sources/static/configuration/scraping-service.md
+++ b/docs/sources/static/configuration/scraping-service.md
@@ -9,6 +9,17 @@ description: Learn about the scraping service
 menuTitle: Scraping service
 title: Scraping service (Beta)
 weight: 600
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ./metrics-config/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/
 ---
 
 # Scraping service (Beta)
@@ -16,7 +27,7 @@ weight: 600
 The Grafana Agent scraping service allows you to cluster a set of Agent processes and distribute the scrape load.
 
 Determining what to scrape is done by writing instance configuration files to an
-[API][api], which then stores the configuration files in a KV store backend.
+[API](ref:api), which then stores the configuration files in a KV store backend.
 All agents in the cluster **must** use the same KV store to see the same set
 of configuration files.
 
@@ -46,7 +57,7 @@ remote_write:
 
 The full set of supported options for an instance configuration file is
 available in the
-[`metrics-config.md` file][metrics].
+[`metrics-config.md` file](ref:metrics).
 
 Multiple instance configuration files are necessary for sharding. Each
 config file is distributed to a particular agent on the cluster based on the
@@ -185,9 +196,3 @@ Information returned by the `/debug/ring` endpoint includes:
    The exact details of the instance ID generation might be specific to the implementation of the Grafana Agent.
 - The time of the "Last Heartbeat" of each instance. The Last Heartbeat is the last time the instance was active in the ring.
 
-{{% docs/reference %}}
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api"
-[api]: "/docs/grafana-cloud/ -> ../api"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ./metrics-config"
-{{% /docs/reference %}}

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -7,6 +7,27 @@ canonical: https://grafana.com/docs/agent/latest/static/operation-guide/
 description: Learn how to operate Grafana Agent
 title: Operation guide
 weight: 700
+refs:
+  metrics:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/metrics-config/
+  api:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/api/#agent-api
+    - pattern: /docs/grafana-cloud/
+      destination: ../api/#agent-api
+  targets:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/#best-practices
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/scraping-service/#best-practices
+  scrape:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+    - pattern: /docs/grafana-cloud/
+      destination: ../configuration/scraping-service/
 ---
 
 # Operation guide
@@ -22,7 +43,7 @@ There are three options to horizontally scale your deployment of Grafana Agents:
   from the machines they run on.
 - [Hashmod sharding](#hashmod-sharding-stable) allows you to roughly shard the
   discovered set of targets by using hashmod/keep relabel rules.
-- The [scraping service][scrape] allows you to cluster Grafana
+- The [scraping service](ref:scrape) allows you to cluster Grafana
   Agents and have them distribute per-tenant configs throughout the cluster.
 
 Each has their own set of tradeoffs:
@@ -57,7 +78,7 @@ Each has their own set of tradeoffs:
     - Smallest load on SD compared to host filtering, as only one Agent is
       responsible for a config.
   - Cons
-    - Centralized configs must discover a [minimal set of targets][targets]
+    - Centralized configs must discover a [minimal set of targets](ref:targets)
       to distribute evenly.
     - Requires running a separate KV store to store the centralized configs.
     - Managing centralized configs adds operational burden over managing a config
@@ -82,7 +103,7 @@ for scraping other targets that are not running on a cluster node, such as the
 Kubernetes control plane API.
 
 If you want to scale your scrape load without host filtering, you can use the
-[scraping service][scrape] instead.
+[scraping service](ref:scrape) instead.
 
 The host name of the Agent is determined by reading `$HOSTNAME`. If `$HOSTNAME`
 isn't defined, the Agent will use Go's [os.Hostname](https://golang.org/pkg/os/#Hostname)
@@ -113,7 +134,7 @@ logic; only `host_filter_relabel_configs` will work.
 
 If the determined hostname matches any of the meta labels, the discovered target
 is allowed. Otherwise, the target is ignored, and will not show up in the
-[targets API][api].
+[targets API](ref:api).
 
 ## Hashmod sharding (Stable)
 
@@ -158,7 +179,7 @@ Instances allow for fine grained control of what data gets scraped and where it
 gets sent. Users can easily define two Instances that scrape different subsets
 of metrics and send them to two completely different remote_write systems.
 
-Instances are especially relevant to the [scraping service mode][scrape],
+Instances are especially relevant to the [scraping service mode](ref:scrape),
 where breaking up your scrape configs into multiple Instances is required for 
 sharding and balancing scrape load across a cluster of Agents.
 
@@ -178,7 +199,7 @@ from that `remote_write` config separated by a `-`.
 
 The shared instances mode is the new default, and the previous behavior is
 deprecated. If you wish to restore the old behavior, set `instance_mode: distinct`
-in the [`metrics_config`][metrics] block of your config file.
+in the [`metrics_config`](ref:metrics) block of your config file.
 
 Shared instances are completely transparent to the user with the exception of
 exposed metrics. With `instance_mode: shared`, metrics for Prometheus components
@@ -190,16 +211,6 @@ individual Instance config. It is recommended to use the default of
 `instance_mode: shared` unless you don't mind the performance hit and really
 need granular metrics.
 
-Users can use the [targets API][api] to see all scraped targets, and the name 
+Users can use the [targets API](ref:api) to see all scraped targets, and the name 
 of the shared instance they were assigned to.
 
-{{% docs/reference %}}
-[scrape]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service"
-[scrape]: "/docs/grafana-cloud/ -> ../configuration/scraping-service"
-[targets]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/scraping-service#best-practices"
-[targets]: "/docs/grafana-cloud/ -> ../configuration/scraping-service#best-practices"
-[api]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/api#agent-api"
-[api]: "/docs/grafana-cloud/ -> ../api#agent-api"
-[metrics]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/metrics-config"
-[metrics]: "/docs/grafana-cloud/ -> ../configuration/metrics-config"
-{{% /docs/reference %}}

--- a/docs/sources/static/operation-guide/_index.md
+++ b/docs/sources/static/operation-guide/_index.md
@@ -10,22 +10,22 @@ weight: 700
 refs:
   metrics:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/metrics-config/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/metrics-config/
   api:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/api/#agent-api
+      destination: /docs/agent/<AGENT_VERSION>/static/api/#agent-api
     - pattern: /docs/grafana-cloud/
       destination: ../api/#agent-api
   targets:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/#best-practices
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/#best-practices
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/scraping-service/#best-practices
   scrape:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/scraping-service/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/scraping-service/
     - pattern: /docs/grafana-cloud/
       destination: ../configuration/scraping-service/
 ---

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -9,6 +9,22 @@ description: Release notes for Grafana Agent static mode
 menuTitle: Release notes
 title: Release notes
 weight: 999
+refs:
+  release-notes-flow:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+  modules:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+  release-notes-operator:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/operator/release-notes/
+    - pattern: /docs/grafana-cloud/
+      destination: ../operator/release-notes/
 ---
 
 # Release notes
@@ -20,19 +36,9 @@ For a complete list of changes to Grafana Agent, with links to pull requests and
 > **Note:** These release notes are specific to Grafana Agent static mode.
 > Other release notes for the different Grafana Agent variants are contained on separate pages:
 >
-> * [Static mode Kubernetes operator release notes][release-notes-operator]
-> * [Flow mode release notes][release-notes-flow]
+> * [Static mode Kubernetes operator release notes](ref:release-notes-operator)
+> * [Flow mode release notes](ref:release-notes-flow)
 
-{{% docs/reference %}}
-[release-notes-operator]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/operator/release-notes"
-[release-notes-operator]: "/docs/grafana-cloud/ -> ../operator/release-notes"
-
-[release-notes-flow]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-[release-notes-flow]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/release-notes"
-
-[Modules]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
-[Modules]: "/docs/grafana-cloud/ -> /docs/agent/<AGENT VERSION>/flow/concepts/modules"
-{{% /docs/reference %}}
 
 ## v0.38
 
@@ -154,7 +160,7 @@ See [Module and Auth Split Migration](https://github.com/prometheus/snmp_exporte
 ### Removal of Dynamic Configuration
 
 The experimental feature Dynamic Configuration has been removed. The use case of dynamic configuration will be replaced
-with [Modules][] in Grafana Agent Flow.
+with [Modules](ref:modules) in Grafana Agent Flow.
 
 ### Breaking change: Removed and renamed tracing metrics
 

--- a/docs/sources/static/release-notes.md
+++ b/docs/sources/static/release-notes.md
@@ -12,17 +12,17 @@ weight: 999
 refs:
   release-notes-flow:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/flow/release-notes/
   modules:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/modules/
     - pattern: /docs/grafana-cloud/
-      destination: /docs/agent/<AGENT VERSION>/flow/concepts/modules/
+      destination: /docs/agent/<AGENT_VERSION>/flow/concepts/modules/
   release-notes-operator:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/operator/release-notes/
+      destination: /docs/agent/<AGENT_VERSION>/operator/release-notes/
     - pattern: /docs/grafana-cloud/
       destination: ../operator/release-notes/
 ---

--- a/docs/sources/static/set-up/install/_index.md
+++ b/docs/sources/static/set-up/install/_index.md
@@ -9,6 +9,12 @@ description: Learn how to install GRafana Agent in static mode
 menuTitle: Install static mode
 title: Install Grafana Agent in static mode
 weight: 100
+refs:
+  data-collection:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT_VERSION>/data-collection/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/send-data/agent/data-collection/
 ---
 
 # Install Grafana Agent in static mode
@@ -38,10 +44,6 @@ Use the Grafana Agent [Kubernetes configuration](/docs/grafana-cloud/monitor-inf
 
 ## Data collection
 
-By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection][] for more information
+By default, Grafana Agent sends anonymous usage information to Grafana Labs. Refer to [data collection](ref:data-collection) for more information
 about what data is collected and how you can opt-out.
 
-{{% docs/reference %}}
-[data collection]: "/docs/agent/ -> /docs/agent/<AGENT_VERSION>/data-collection.md"
-[data collection]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/send-data/agent/data-collection.md"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -12,27 +12,27 @@ weight: 700
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/
   linux:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-linux/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-linux/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/#standalone-binary
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/#standalone-binary
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/#standalone-binary
   windows:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-on-windows/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-on-windows/
   macos:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-macos/
     - pattern: /docs/grafana-cloud/
       destination: ./install-agent-macos/
 ---

--- a/docs/sources/static/set-up/install/install-agent-binary.md
+++ b/docs/sources/static/set-up/install/install-agent-binary.md
@@ -9,6 +9,32 @@ description: Learn how to install Grafana Agent in static mode as a standalone b
 menuTitle: Standalone
 title: Install Grafana Agent in static mode as a standalone binary
 weight: 700
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/
+  linux:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-linux/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/#standalone-binary
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/#standalone-binary
+  windows:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-on-windows/
+  macos:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/
+    - pattern: /docs/grafana-cloud/
+      destination: ./install-agent-macos/
 ---
 
 # Install Grafana Agent in static mode as a standalone binary
@@ -25,9 +51,9 @@ ppc64le builds are considered secondary release targets and do not have the same
 
 The binary executable will run Grafana Agent in standalone mode. If you want to run Grafana Agent as a service, refer to the installation instructions for:
 
-* [Linux][linux]
-* [macOS][macos]
-* [Windows][windows]
+* [Linux](ref:linux)
+* [macOS](ref:macos)
+* [Windows](ref:windows)
 
 ## Download Grafana Agent
 
@@ -49,18 +75,6 @@ To download the Grafana Agent as a standalone binary, perform the following step
 
 ## Next steps
 
-* [Start Grafana Agent][start]
-* [Configure Grafana Agent][configure]
+* [Start Grafana Agent](ref:start)
+* [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[linux]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-linux"
-[linux]: "/docs/grafana-cloud/ -> ./install-agent-linux"
-[macos]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos"
-[macos]: "/docs/grafana-cloud/ -> ./install-agent-macos"
-[windows]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-on-windows"
-[windows]: "/docs/grafana-cloud/ -> ./install-agent-on-windows"
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent#standalone-binary"
-[start]: "/docs/grafana-cloud/ -> ../start-agent#standalone-binary"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -12,12 +12,12 @@ weight: 200
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-docker.md
+++ b/docs/sources/static/set-up/install/install-agent-docker.md
@@ -9,6 +9,17 @@ description: Learn how to run Grafana Agent in static mode in a Docker container
 menuTitle: Docker
 title: Run Grafana Agent in static mode in a Docker container
 weight: 200
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Run Grafana Agent in static mode in a Docker container
@@ -24,7 +35,7 @@ Grafana Agent is available as a Docker container image on the following platform
 ## Before you begin
 
 * Install [Docker][] on your computer.
-* Create and save a Grafana Agent YAML [configuration file][configure] on your computer.
+* Create and save a Grafana Agent YAML [configuration file](ref:configure) on your computer.
 
 [Docker]: https://docker.io
 
@@ -67,12 +78,6 @@ For the flags to work correctly, you must expose the paths on your Windows host 
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in static mode on Linux
 menuTitle: Linux
 title: Install Grafana Agent in static mode on Linux
 weight: 400
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Install Grafana Agent in static mode on Linux
@@ -214,12 +225,6 @@ Logs of Grafana Agent can be found by running the following command in a termina
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-linux.md
+++ b/docs/sources/static/set-up/install/install-agent-linux.md
@@ -12,12 +12,12 @@ weight: 400
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -12,12 +12,12 @@ weight: 500
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
 ---

--- a/docs/sources/static/set-up/install/install-agent-macos.md
+++ b/docs/sources/static/set-up/install/install-agent-macos.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in static mode on macOS
 menuTitle: macOS
 title: Install Grafana Agent in static mode on macOS
 weight: 500
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
 ---
 
 # Install Grafana Agent in static mode on macOS
@@ -74,7 +85,7 @@ brew uninstall grafana-agent
     touch $(brew --prefix)/etc/grafana-agent/config.yml
     ```
 
-1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent][configure] for more information.
+1. Edit `$(brew --prefix)/etc/grafana-agent/config.yml` and add the configuration blocks for your specific telemetry needs. Refer to [Configure Grafana Agent](ref:configure) for more information.
 
 {{% admonition type="note" %}}
 To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud integration. Refer to [how to install an integration](/docs/grafana-cloud/data-configuration/integrations/install-and-manage-integrations/) and [macOS integration](/docs/grafana-cloud/data-configuration/integrations/integration-reference/integration-macos-node/).
@@ -82,12 +93,6 @@ To send your data to Grafana Cloud, set up Grafana Agent using the Grafana Cloud
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -12,12 +12,12 @@ weight: 600
 refs:
   start:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/start-agent/
     - pattern: /docs/grafana-cloud/
       destination: ../start-agent/
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+      destination: /docs/agent/<AGENT_VERSION>/static/configuration/create-config-file/
     - pattern: /docs/grafana-cloud/
       destination: ../../configuration/create-config-file/
 ---

--- a/docs/sources/static/set-up/install/install-agent-on-windows.md
+++ b/docs/sources/static/set-up/install/install-agent-on-windows.md
@@ -9,6 +9,17 @@ description: Learn how to install Grafana Agent in static mode on Windows
 menuTitle: Windows
 title: Install Grafana Agent in static mode on Windows
 weight: 600
+refs:
+  start:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/start-agent/
+    - pattern: /docs/grafana-cloud/
+      destination: ../start-agent/
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/configuration/create-config-file/
+    - pattern: /docs/grafana-cloud/
+      destination: ../../configuration/create-config-file/
 ---
 
 # Install Grafana Agent in static mode on Windows
@@ -142,12 +153,6 @@ Refer to [windows_events](/docs/loki/latest/clients/promtail/configuration/#wind
 
 ## Next steps
 
-- [Start Grafana Agent][start]
-- [Configure Grafana Agent][configure]
+- [Start Grafana Agent](ref:start)
+- [Configure Grafana Agent](ref:configure)
 
-{{% docs/reference %}}
-[start]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/start-agent"
-[start]: "/docs/grafana-cloud/ -> ../start-agent"
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/configuration/create-config-file"
-[configure]: "/docs/grafana-cloud/ -> ../../configuration/create-config-file"
-{{% /docs/reference %}}

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -10,7 +10,7 @@ weight: 200
 refs:
   configure:
     - pattern: /docs/agent/
-      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/#configure
+      destination: /docs/agent/<AGENT_VERSION>/static/set-up/install/install-agent-macos/#configure
     - pattern: /docs/grafana-cloud/
       destination: ./install/install-agent-macos/#configure
 ---

--- a/docs/sources/static/set-up/start-agent.md
+++ b/docs/sources/static/set-up/start-agent.md
@@ -7,6 +7,12 @@ description: Learn how to start, restart, and stop Grafana Agent in static mode
 menuTitle: Start static mode
 title: Start, restart, and stop Grafana Agent in static mode
 weight: 200
+refs:
+  configure:
+    - pattern: /docs/agent/
+      destination: /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos/#configure
+    - pattern: /docs/grafana-cloud/
+      destination: ./install/install-agent-macos/#configure
 ---
 
 # Start, restart, and stop Grafana Agent in static mode
@@ -106,7 +112,7 @@ brew services stop grafana-agent
 By default, logs are written to `$(brew --prefix)/var/log/grafana-agent.log` and
 `$(brew --prefix)/var/log/grafana-agent.err.log`.
 
-If you followed [Configure][configure] steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
+If you followed [Configure](ref:configure) steps in the macOS install instructions and changed the path where logs are written, refer to your current copy of the Grafana Agent formula to locate your log files.
 
 ## Windows
 
@@ -156,7 +162,3 @@ Replace the following:
 * `BINARY_PATH`: The path to the Grafana Agent binary file
 * `CONFIG_FILE`: The path to the Grafana Agent configuration file.
 
-{{% docs/reference %}}
-[configure]: "/docs/agent/ -> /docs/agent/<AGENT VERSION>/static/set-up/install/install-agent-macos#configure"
-[configure]: "/docs/grafana-cloud/ -> ./install/install-agent-macos/#configure"
-{{% /docs/reference %}}


### PR DESCRIPTION
You can use `ref` URIs in admonitions (or any shortcodes) because they are inline and not subject to the issues noted in the [`admonition` shortcode](https://grafana.com/docs/writers-toolkit/write/shortcodes/#code-shortcode:~:text=to%20core%20understanding.-,WARNING,For%20more%20information%2C%20refer%20to%20Markdown%20Reference%20Links%20in%20Shortcodes.,-Examples).

The `ref` URIs perform the same pattern matching as `docs/reference` but don't require the use of reference-style links and the destinations are ordinary (full) URLs that can include version substitution. Unlike `docs/reference`, the implementation doesn't use `relref` so you don't have to be careful with omitting trailing slashes and the links will follow redirects.

Documentation: https://grafana.com/docs/writers-toolkit/write/links/#link-from-source-content-thats-used-in-multiple-projects

To check the links, refer to the deploy preview in https://github.com/grafana/website/pull/19630.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
