### PR TITLE
Backport: pyroscope.scrape: standarize profile names

### DIFF
--- a/internal/component/pyroscope/scrape/target.go
+++ b/internal/component/pyroscope/scrape/target.go
@@ -65,9 +65,23 @@ type Target struct {
 func NewTarget(lbls, discoveredLabels labels.Labels, params url.Values) *Target {
 	publicLabels := make(labels.Labels, 0, len(lbls))
 	for _, l := range lbls {
-		if !strings.HasPrefix(l.Name, model.ReservedLabelPrefix) {
-			publicLabels = append(publicLabels, l)
+		if strings.HasPrefix(l.Name, model.ReservedLabelPrefix) {
+			continue
 		}
+
+		// the fact that godeltaprof was used scraping should not be user visible
+		if l.Name == pprofGoDeltaProfMemory {
+			switch l.Value {
+			case pprofGoDeltaProfMemory:
+				l.Value = pprofMemory
+			case pprofGoDeltaProfBlock:
+				l.Value = pprofBlock
+			case pprofGoDeltaProfMutex:
+				l.Value = pprofMutex
+			}
+		}
+
+		publicLabels = append(publicLabels, l)
 	}
 	url := urlFromTarget(lbls, params)
 

--- a/internal/component/pyroscope/scrape/target_test.go
+++ b/internal/component/pyroscope/scrape/target_test.go
@@ -236,3 +236,50 @@ func Test_targetsFromGroup(t *testing.T) {
 	require.Equal(t, expected, active)
 	require.Empty(t, dropped)
 }
+
+// Test that the godeltaprof is not surfaced publicly
+func Test_NewTarget_godeltaprof(t *testing.T) {
+	withGodeltaprof := NewTarget(
+		labels.FromMap(map[string]string{
+			model.AddressLabel:    "localhost:9094",
+			serviceNameLabel:      "docker-container",
+			model.MetricNameLabel: pprofGoDeltaProfMemory,
+			ProfilePath:           "/debug/pprof/delta_heap",
+			model.SchemeLabel:     "http",
+			"foo":                 "bar",
+			"instance":            "localhost:9094",
+		}),
+		labels.FromMap(map[string]string{
+			model.AddressLabel:             "localhost:9094",
+			"__meta_docker_container_name": "docker-container",
+			model.MetricNameLabel:          pprofGoDeltaProfMemory,
+			ProfilePath:                    "/debug/pprof/delta_heap",
+			model.SchemeLabel:              "http",
+			"foo":                          "bar",
+		}),
+		url.Values{},
+	)
+	withoutGodeltaprof := NewTarget(
+		labels.FromMap(map[string]string{
+			model.AddressLabel:    "localhost:9094",
+			serviceNameLabel:      "docker-container",
+			model.MetricNameLabel: pprofMemory,
+			ProfilePath:           "/debug/pprof/heap",
+			model.SchemeLabel:     "http",
+			"foo":                 "bar",
+			"instance":            "localhost:9094",
+		}),
+		labels.FromMap(map[string]string{
+			model.AddressLabel:             "localhost:9094",
+			"__meta_docker_container_name": "docker-container",
+			model.MetricNameLabel:          pprofMemory,
+			ProfilePath:                    "/debug/pprof/heap",
+			model.SchemeLabel:              "http",
+			"foo":                          "bar",
+		}),
+		url.Values{},
+	)
+
+	require.NotEqual(t, withGodeltaprof.allLabels, withoutGodeltaprof.allLabels)
+	require.Equal(t, withGodeltaprof.publicLabels, withoutGodeltaprof.publicLabels)
+}


### PR DESCRIPTION
Backport of https://github.com/grafana/alloy/pull/662