### PR TITLE
Fix date of 0.40.5 release (release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
-v0.40.5 (2024-04-15)
+v0.40.5 (2024-05-15)
 --------------------
 
 ### Breaking changes


### PR DESCRIPTION
I put in the wrong date in the changelog... Thankfully we haven't announced the release yet.

@rfratto, is it a big problem that the CI has already ran for the 0.40.5 tag with the old date? Do we need to delete the artifacts, or can we just overwrite the tag?