### PR TITLE
Fix 404 errors and bad canonical URLs in Agent docs

### DIFF
--- a/docs/sources/flow/concepts/custom_components.md
+++ b/docs/sources/flow/concepts/custom_components.md
@@ -5,7 +5,7 @@ aliases:
 - /docs/grafana-cloud/monitor-infrastructure/agent/flow/concepts/custom-components/
 - /docs/grafana-cloud/monitor-infrastructure/integrations/agent/flow/concepts/custom-components/
 - /docs/grafana-cloud/send-data/agent/flow/concepts/custom-components/
-canonical: https://grafana.com/docs/agent/latest/flow/concepts/custom-components/
+canonical: https://grafana.com/docs/agent/latest/flow/concepts/custom_components/
 description: Learn about custom components
 title: Custom components
 weight: 300

--- a/docs/sources/flow/tasks/metamonitoring.md
+++ b/docs/sources/flow/tasks/metamonitoring.md
@@ -1,5 +1,5 @@
 ---
-canonical: https://grafana.com/docs/agent/latest/flow/tasks/setup-metamonitoring/
+canonical: https://grafana.com/docs/agent/latest/flow/tasks/metamonitoring/
 description: Learn how to set up meta-monitoring for Grafana Agent Flow
 title: Set up meta-monitoring
 weight: 200

--- a/docs/sources/shared/wal-data-retention.md
+++ b/docs/sources/shared/wal-data-retention.md
@@ -92,7 +92,7 @@ Deleting a WAL segment or a WAL file permanently deletes the stored WAL data.
 
 To delete the corrupted WAL:
 
-1. [Stop][] Grafana Agent.
+1. Stop Grafana Agent.
 1. Find and delete the contents of the `wal` directory.
 
    By default the `wal` directory is a subdirectory
@@ -107,10 +107,9 @@ To delete the corrupted WAL:
    * `prometheus.remote_write` component running in Flow mode
    {{< /admonition >}}
 
-1. [Start][Stop] Grafana Agent and verify that the WAL is working correctly.
+1. Start Grafana Agent and verify that the WAL is working correctly.
 
 [WAL block]: /docs/agent/<AGENT_VERSION>/flow/reference/components/prometheus.remote_write#wal-block
 [metrics config]: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config
-[Stop]: /docs/agent/<AGENT_VERSION>/flow/get-started/start-agent
 [wal_directory]: /docs/agent/<AGENT_VERSION>/static/configuration/metrics-config
 [run]: /docs/agent/<AGENT_VERSION>/flow/reference/cli/run


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

This PR catches and fixes some 404 errors in the Agent docs.

The Start/Stop link in the shared WAL topic was removed. This topic is shared across multiple products and the destination is different depending on the product. It was simpler to just remove the xref link that try to sort out the various destinations. The xref link isn't that important to the understanding of the topic.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated