### PR TITLE
fix for panic with snmp exporter from the recent version upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Main (unreleased)
 
 ### Bugfixes
 
+- Fix panic for `prometheus.exporter.snmp` and snmp_exporter integration
+  introduced in v0.40.5 with a version upgrade. This was due to an
+  uninitialized new metric for the exporter. (@erikbaranowski)
+
 - Fix an issue where JSON string array elements were not parsed correctly in `loki.source.cloudflare`. (@thampiotr)
 
 - Fix SSRF vulnerability in `faro.receiver` by disabling source map download. (@hainenber)

--- a/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/static/integrations/snmp_exporter/snmp_exporter.go
@@ -155,6 +155,13 @@ func NewSNMPMetrics(reg prometheus.Registerer) collector.Metrics {
 				Help:      "Number of SNMP packet retries.",
 			},
 		),
+		SNMPInflight: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "request_in_flight",
+				Help:      "Current number of SNMP scrapes being requested.",
+			},
+		),
 	}
 }
 

--- a/static/integrations/snmp_exporter/snmp_exporter.go
+++ b/static/integrations/snmp_exporter/snmp_exporter.go
@@ -155,7 +155,7 @@ func NewSNMPMetrics(reg prometheus.Registerer) collector.Metrics {
 				Help:      "Number of SNMP packet retries.",
 			},
 		),
-		SNMPInflight: promauto.NewGauge(
+		SNMPInflight: promauto.With(reg).NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "request_in_flight",


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

#### Which issue(s) this PR fixes

Fixes #6918

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

This was validated as fixed by reproducing the error on main and then validating the fix on this branch with the following config (thanks @ptodev):

```
server:
  log_level: debug
integrations:
  snmp:
    enabled: true
    scrape_interval: 1m
    scrape_timeout: 30s
    snmp_targets:
      - name: testing
        address: demo.pysnmp.com
        module: if_mib
        auth: public_v2
```

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated