### PR TITLE
Fix issue with config reload when using a log pipeline with a metric stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ Main (unreleased)
 - A new `otelcol.exporter.debug` component for printing OTel telemetry from 
   other `otelcol` components to the console. (@BarunKGP)
 
+### Bugfixes
+
+- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn't changed.
+  The bug only affected the "metrics" and "logs" subsystems in Static mode. (@ptodev)
+
+- Fix a bug in Static mode and Flow which prevented config reloads to work if a Loki `metrics` stage is in the pipeline.
+  This resulted in a "failed to unregister all metrics from previous promtail" message. (@ptodev)
+
 v0.41.1 (2024-06-07)
 --------------------
 
@@ -27,11 +35,6 @@ v0.41.1 (2024-06-07)
 ### Enhancements
 
 - Updated pyroscope to v0.4.6 introducing `symbols_map_size` and `pid_map_size` configuration. (@simonswine)
-
-### Bugfixes
-
-- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn't changed.
-  The bug only affected the "metrics" and "logs" subsystems in Static mode.
 
 v0.41.0 (2024-05-31)
 --------------------

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -717,6 +717,10 @@ The following blocks are supported inside the definition of `stage.metrics`:
 | metric.gauge     | [metric.gauge][]     | Defines a `gauge` metric.     | no       |
 | metric.histogram | [metric.histogram][] | Defines a `histogram` metric. | no       |
 
+{{< admonition type="note" >}}
+If the configuration file for {{< param "PRODUCT_ROOT_NAME" >}} is reloaded, the metrics will be reset. 
+{{< /admonition >}}
+
 [metric.counter]: #metriccounter-block
 [metric.gauge]: #metricgauge-block
 [metric.histogram]: #metrichistogram-block

--- a/docs/sources/flow/reference/components/loki.process.md
+++ b/docs/sources/flow/reference/components/loki.process.md
@@ -718,7 +718,7 @@ The following blocks are supported inside the definition of `stage.metrics`:
 | metric.histogram | [metric.histogram][] | Defines a `histogram` metric. | no       |
 
 {{< admonition type="note" >}}
-If the configuration file for {{< param "PRODUCT_ROOT_NAME" >}} is reloaded, the metrics will be reset. 
+The metrics will be reset if you reload the {{< param "PRODUCT_ROOT_NAME" >}} configuration file.
 {{< /admonition >}}
 
 [metric.counter]: #metriccounter-block

--- a/internal/component/loki/process/process.go
+++ b/internal/component/loki/process/process.go
@@ -127,7 +127,7 @@ func (c *Component) Update(args component.Arguments) error {
 		if err != nil {
 			return err
 		}
-		c.entryHandler = loki.NewEntryHandler(c.processOut, func() {})
+		c.entryHandler = loki.NewEntryHandler(c.processOut, func() { pipeline.Cleanup() })
 		c.processIn = pipeline.Wrap(c.entryHandler).Chan()
 		c.stages = newArgs.Stages
 	}

--- a/internal/component/loki/process/process_test.go
+++ b/internal/component/loki/process/process_test.go
@@ -617,7 +617,7 @@ loki_process_custom_paulin_test{filename="/var/log/pods/agent/agent/1.log",foo="
 		}
 	}
 
-	// Make sure there are no metrics - there is no metrics stage in the latest config.
+	// Make sure there are still no metrics after sending log entries.
 	if err := testutil.GatherAndCompare(reg,
 		strings.NewReader("")); err != nil {
 		t.Fatalf("mismatch metrics: %v", err)

--- a/internal/util/unregisterer.go
+++ b/internal/util/unregisterer.go
@@ -18,6 +18,22 @@ func WrapWithUnregisterer(reg prometheus.Registerer) *Unregisterer {
 	}
 }
 
+// An "unchecked collector" is a collector which returns an empty description.
+// It is described in the Prometheus documentation, here:
+// https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#hdr-Custom_Collectors_and_constant_Metrics
+//
+// > Alternatively, you could return no Desc at all, which will mark the Collector “unchecked”.
+// > No checks are performed at registration time, but metric consistency will still be ensured at scrape time,
+// > i.e. any inconsistencies will lead to scrape errors. Thus, with unchecked Collectors,
+// > the responsibility to not collect metrics that lead to inconsistencies in the total scrape result
+// > lies with the implementer of the Collector. While this is not a desirable state, it is sometimes necessary.
+// > The typical use case is a situation where the exact metrics to be returned by a Collector cannot be predicted
+// > at registration time, but the implementer has sufficient knowledge of the whole system to guarantee metric consistency.
+//
+// Unchecked collectors are used in the Loki "metrics" stage of the Loki "process" component.
+//
+// The isUncheckedCollector function is similar to how Prometheus' Go client extracts the metric description:
+// https://github.com/prometheus/client_golang/blob/45f1e72421d9d11af6be784ad60b7389f7543e70/prometheus/registry.go#L372-L381
 func isUncheckedCollector(c prometheus.Collector) bool {
 	descChan := make(chan *prometheus.Desc, 10)
 

--- a/internal/util/unregisterer_test.go
+++ b/internal/util/unregisterer_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_UnregisterTwice_NormalCollector(t *testing.T) {
+	u := WrapWithUnregisterer(prometheus.NewRegistry())
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_metric",
+		Help: "Test metric.",
+	})
+	u.Register(c)
+	require.True(t, u.Unregister(c))
+	require.False(t, u.Unregister(c))
+}
+
+type uncheckedCollector struct{}
+
+func (uncheckedCollector) Describe(chan<- *prometheus.Desc) {}
+
+func (uncheckedCollector) Collect(chan<- prometheus.Metric) {}
+
+var _ prometheus.Collector = uncheckedCollector{}
+
+func Test_UnregisterTwice_UncheckedCollector(t *testing.T) {
+	u := WrapWithUnregisterer(prometheus.NewRegistry())
+	c := uncheckedCollector{}
+	u.Register(c)
+	require.True(t, u.Unregister(c))
+	require.True(t, u.Unregister(c))
+}

--- a/static/traces/traces_test.go
+++ b/static/traces/traces_test.go
@@ -225,7 +225,7 @@ configs:
 	err := dec.Decode(&cfg)
 	require.NoError(t, err)
 
-	logBuffer := bytes.Buffer{}
+	logBuffer := util.SyncBuffer{}
 	logger := log.NewLogfmtLogger(&logBuffer)
 
 	traces, err := New(nil, nil, prometheus.NewRegistry(), cfg, logger)


### PR DESCRIPTION
#### PR Description

There is a longstanding bug which prevents the agent config from being reloaded when there is a `metrics` stage in a logging pipeline. 

#### Which issue(s) this PR fixes

Fixes #2754

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [x] Documentation added
- [x] Tests updated
- [ ] Config converters updated