### PR TITLE
Fix issue with unnecessary config reload in static mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ v0.41.1 (2024-06-07)
 
 - Updated pyroscope to v0.4.6 introducing `symbols_map_size` and `pid_map_size` configuration. (@simonswine)
 
+### Bugfixes
+
+- Fix an issue which caused the config to be reloaded if a config reload was triggered but the config hasn't changed.
+  The bug only affected the "metrics" and "logs" subsystems in Static mode.
 
 v0.41.0 (2024-05-31)
 --------------------

--- a/internal/util/syncbuffer.go
+++ b/internal/util/syncbuffer.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"bytes"
+	"sync"
+)
+
+// SyncBuffer wraps around a bytes.Buffer and makes it safe to use from
+// multiple goroutines.
+type SyncBuffer struct {
+	mut sync.RWMutex
+	buf bytes.Buffer
+}
+
+func (sb *SyncBuffer) Bytes() []byte {
+	sb.mut.RLock()
+	defer sb.mut.RUnlock()
+
+	return sb.buf.Bytes()
+}
+
+func (sb *SyncBuffer) String() string {
+	sb.mut.RLock()
+	defer sb.mut.RUnlock()
+
+	return sb.buf.String()
+}
+
+func (sb *SyncBuffer) Write(p []byte) (n int, err error) {
+	sb.mut.Lock()
+	defer sb.mut.Unlock()
+
+	return sb.buf.Write(p)
+}

--- a/static/logs/logs.go
+++ b/static/logs/logs.go
@@ -162,7 +162,7 @@ func (i *Instance) ApplyConfig(c *InstanceConfig, g GlobalConfig, dryRun bool) e
 	if err != nil {
 		return fmt.Errorf("failed to marshal new logs instance config: %w", err)
 	}
-	newConfig := string(newConfigByteArr[:])
+	newConfig := string(newConfigByteArr)
 	if newConfig == i.previousConfig {
 		level.Debug(i.log).Log("msg", "instance config hasn't changed, not recreating Promtail")
 		return nil

--- a/static/metrics/agent.go
+++ b/static/metrics/agent.go
@@ -234,7 +234,7 @@ func (a *Agent) ApplyConfig(cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal new config: %w", err)
 	}
-	newConfig := string(newConfigByteArr[:])
+	newConfig := string(newConfigByteArr)
 	if newConfig == a.previousConfig {
 		level.Debug(a.logger).Log("msg", "not recreating metrics instance because config hasn't changed")
 		return nil

--- a/static/traces/instance.go
+++ b/static/traces/instance.go
@@ -57,6 +57,7 @@ func (i *Instance) ApplyConfig(logsSubsystem *logs.Logs, promInstanceManager ins
 
 	if util.CompareYAML(cfg, i.cfg) {
 		// No config change
+		i.logger.Debug("tracing config won't be recreated because it hasn't changed")
 		return nil
 	}
 	i.cfg = cfg


### PR DESCRIPTION
#### PR Description

When a config reload is triggered, the config shouldn't be reloaded if it hasn't changed. Unfortunately, there was a bug which prevented this for the "metrics" and "logs" subsystems:

* The `X-Agent-Id` header isn't in the user-defined config.
* In the "logs" subsytem, the `scrape_configs`/`static_configs` section, there might be a `targets: [localhost]` which was [added by default](https://grafana.com/docs/loki/latest/send-data/promtail/configuration/#static_configs) by Promtail because the user didn't set it explicitly

For example, when using [static_mode.yaml.txt](https://github.com/user-attachments/files/16016252/static_mode.yaml.txt), the Agent tries interprets the new config as [example_incoming.yaml.txt](https://github.com/user-attachments/files/16016270/example_incoming.yaml.txt). This doesn't match the way it thinks the "current" config that it uses is defined([example_running.yaml.txt](https://github.com/user-attachments/files/16016269/example_running.yaml.txt)), so it does a config reload. This issue is not present in Flow - it's only in static mode.

There might also be similar issues that cause mismatch in configs. It's possible that I don't see all such issues, since my config file is using very few functionality. The only sure way of eliminating these issues that I can think of is to store the incoming config in a string, as this PR is doing.

#### Notes to the Reviewer

This is a prerequisite for #6971

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [x] Tests updated
- [ ] Config converters updated