### PR TITLE
Update build image to Go 1.22.5

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-# NOTE: The GO_RUNTIME is used to switch between the default Google go runtime and mcr.microsoft.com/oss/go/microsoft/golang:1.22.1-bullseye which is a Microsoft
+# NOTE: The GO_RUNTIME is used to switch between the default Google go runtime and mcr.microsoft.com/oss/go/microsoft/golang:1.22.5-bullseye which is a Microsoft
 # fork of go that allows using windows crypto instead of boring crypto. Details at https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ARG GO_RUNTIME=mustoverride
 

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.22.1-windowsservercore-1809
+FROM library/golang:1.22.5-windowsservercore-1809
 
 SHELL ["powershell", "-command"]
 


### PR DESCRIPTION
This PR needs to be merged in order for #6980 to be updated to use the new base image. #6980 will update Agent to use Go 1.22.5.