### PR TITLE
Update Helm to Agent 0.42.0

### DIFF
--- a/operations/helm/charts/grafana-agent/CHANGELOG.md
+++ b/operations/helm/charts/grafana-agent/CHANGELOG.md
@@ -7,6 +7,13 @@ This document contains a historical list of changes between releases. Only
 changes that impact end-user behavior are listed; changes to documentation or
 internal API changes are not present.
 
+0.42.0 (2024-07-24)
+----------
+
+### Enhancements
+
+- Update Grafana Agent version to v0.42.0. (@ptodev)
+
 0.41.0 (2024-06-07)
 ----------
 

--- a/operations/helm/charts/grafana-agent/Chart.yaml
+++ b/operations/helm/charts/grafana-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: grafana-agent
 description: 'Grafana Agent'
 type: application
-version: 0.41.0
-appVersion: 'v0.41.1'
+version: 0.42.0
+appVersion: 'v0.42.0'
 
 dependencies:
   - name: crds

--- a/operations/helm/charts/grafana-agent/README.md
+++ b/operations/helm/charts/grafana-agent/README.md
@@ -1,6 +1,6 @@
 # Grafana Agent Helm chart
 
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.41.0](https://img.shields.io/badge/Version-0.41.0-informational?style=flat-square) ![AppVersion: v0.41.1](https://img.shields.io/badge/AppVersion-v0.41.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square) ![AppVersion: v0.42.0](https://img.shields.io/badge/AppVersion-v0.42.0-informational?style=flat-square)
 
 Helm chart for deploying [Grafana Agent][] to Kubernetes.
 

--- a/operations/helm/tests/additional-serviceaccount-label/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/additional-serviceaccount-label/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/clustering/grafana-agent/templates/controllers/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/controller-volumes-extra/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset-hostnetwork/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/create-daemonset/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment-autoscaling/grafana-agent/templates/controllers/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/create-deployment/grafana-agent/templates/controllers/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset-autoscaling/grafana-agent/templates/controllers/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
+++ b/operations/helm/tests/create-statefulset/grafana-agent/templates/controllers/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/custom-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/default-values/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/enable-servicemonitor-tls/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor-tls/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/enable-servicemonitor/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/enable-servicemonitor/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/envFrom/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/existing-config/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-env/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/extra-ports/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/faro-ingress/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/global-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
@@ -32,7 +32,7 @@ spec:
         - name: global-cred
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/global-image-registry/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/global-image-registry/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: quay.io/grafana/agent:v0.41.1
+          image: quay.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/initcontainers/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/initcontainers/grafana-agent/templates/controllers/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
             name: geoip
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/local-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-pullsecrets/grafana-agent/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
         - name: local-cred
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/local-image-registry/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/local-image-registry/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: quay.io/grafana/agent:v0.41.1
+          image: quay.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/nodeselectors-and-tolerations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nodeselectors-and-tolerations/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/nonroot/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/nonroot/grafana-agent/templates/controllers/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/pod_annotations/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/pod_annotations/grafana-agent/templates/controllers/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/sidecars/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/sidecars/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
+++ b/operations/helm/tests/static-mode/grafana-agent/templates/controllers/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/agent/config.yaml

--- a/operations/helm/tests/topologyspreadconstraints/grafana-agent/templates/controllers/deployment.yaml
+++ b/operations/helm/tests/topologyspreadconstraints/grafana-agent/templates/controllers/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: grafana-agent
       containers:
         - name: grafana-agent
-          image: docker.io/grafana/agent:v0.41.1
+          image: docker.io/grafana/agent:v0.42.0
           imagePullPolicy: IfNotPresent
           args:
             - run


### PR DESCRIPTION
Preparing for release 0.42.0.

The Helm chart versions aren't supposed to track the Agent versions, but in this case they both align.