### PR TITLE
Make EnableProtobufNegotiation configurable to enable native histogram scraping in static mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ v0.43.3 (2024-09-26)
 ### Bugfixes
 
 - Windows installer: Don't quote Alloy's binary path in the Windows Registry. (@jkroepke)
+- Agent static mode: Add configuration field to allow setting EnableProtobufNegotiation on prometheus scraper so it scrapes native histograms. (@reimirno)
 
 v0.43.2 (2024-09-25)
 -------------------------

--- a/static/metrics/instance/global.go
+++ b/static/metrics/instance/global.go
@@ -17,6 +17,8 @@ type GlobalConfig struct {
 	Prometheus  config.GlobalConfig         `yaml:",inline"`
 	RemoteWrite []*config.RemoteWriteConfig `yaml:"remote_write,omitempty"`
 
+	EnableProtobufNegotiation bool `yaml:"enable_protobuf_negotiation,omitempty"`
+
 	ExtraMetrics      bool          `yaml:"-"`
 	DisableKeepAlives bool          `yaml:"-"`
 	IdleConnTimeout   time.Duration `yaml:"-"`

--- a/static/metrics/instance/instance.go
+++ b/static/metrics/instance/instance.go
@@ -439,8 +439,9 @@ func (i *Instance) initialize(ctx context.Context, reg prometheus.Registerer, cf
 	i.storage = storage.NewFanout(i.logger, i.wal, i.remoteStore)
 
 	opts := &scrape.Options{
-		ExtraMetrics:      cfg.global.ExtraMetrics,
-		HTTPClientOptions: []config_util.HTTPClientOption{},
+		ExtraMetrics:              cfg.global.ExtraMetrics,
+		HTTPClientOptions:         []config_util.HTTPClientOption{},
+		EnableProtobufNegotiation: cfg.global.EnableProtobufNegotiation,
 	}
 
 	if cfg.global.DisableKeepAlives {


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Add `EnableProtobufNegotiation` to static config so as to enable native histogram scraping in static mode.

A similar issue for flow mode has been raised in https://github.com/grafana/agent/issues/5136 and fixed in https://github.com/grafana/agent/pull/5335. This PR fixes it for static mode. NOTE - For static mode, `scrape_classic_histograms` is already supported so no action needed in this PR.

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes #7056

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated