### PR TITLE
Add support for SafeAuthorization from ServiceMonitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ internal API changes are not present.
 Main (unreleased)
 -----------------
 
+- Add support for SafeAuthorization from ServiceMonitor`s (@mate4st)
+
 v0.43.3 (2024-09-26)
 -------------------------
 
@@ -31,7 +33,7 @@ v0.43.0 (2024-09-11)
 
 - Fix a memory leak which would occur any time `loki.process` had its configuration reloaded. (@ptodev)
 
-- Fix a bug where custom components would not shadow the stdlib. If you have a module whose name conflicts with an stdlib function 
+- Fix a bug where custom components would not shadow the stdlib. If you have a module whose name conflicts with an stdlib function
   and if you use this exact function in your config, then you will need to rename your module. (@wildum)
 
 - Fix an issue where nested import.git config blocks could conflict if they had the same labels. (@wildum)
@@ -60,7 +62,7 @@ v0.42.0 (2024-07-24)
 
 ### Features
 
-- A new `otelcol.exporter.debug` component for printing OTel telemetry from 
+- A new `otelcol.exporter.debug` component for printing OTel telemetry from
   other `otelcol` components to the console. (@BarunKGP)
 
 ### Bugfixes
@@ -222,7 +224,7 @@ v0.40.4 (2024-04-12)
   * show the offset/lag for all consumer group or only the connected ones
   * set the minimum number of topics to monitor
   * enable/disable auto-creation of requested topics if they don't already exist
-  * regex to exclude topics / groups 
+  * regex to exclude topics / groups
   * added metric kafka_broker_info
 
 - In `prometheus.exporter.kafka`, the interpolation table used to compute estimated lag metrics is now pruned

--- a/static/operator/config/templates/agent-metrics.libsonnet
+++ b/static/operator/config/templates/agent-metrics.libsonnet
@@ -1,7 +1,7 @@
 // agent-metrics.libsonnet is the entrypoint for rendering a Grafana Agent
 // config file for metrics based on the Operator custom resources.
 //
-// When writing an object, any field will null will be removed from the final
+// When writing an object, any field with null will be removed from the final
 // YAML. This is useful as we don't want to always translate unfilled values
 // from the custom resources to a field in the YAML.
 //

--- a/static/operator/config/templates/component/metrics/service_monitor.libsonnet
+++ b/static/operator/config/templates/component/metrics/service_monitor.libsonnet
@@ -77,6 +77,11 @@ function(
     password: secrets.valueForSecret(meta.Namespace, endpoint.BasicAuth.Password),
   },
 
+  authorization: if endpoint.Authorization != null then {
+    type: optionals.string(endpoint.Authorization.Type),
+    credentials_file: secrets.pathForSecret(meta.Namespace, endpoint.Authorization.Credentials),
+  },
+
   relabel_configs: (
     [{ source_labels: ['job'], target_label: '__tmp_prometheus_job_name' }] +
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description

Adds  [SafeAuthorization](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.SafeAuthorization)  support to scrape_config based on ServiceMonitor.


#### Which issue(s) this PR fixes

ServiceMonitor with authorization set, won`t be configured in Grafana agent. The secret however is detected and loaded into the Grafana aget pod. Its just the scrape_config that does not contain the configuration for it. 


<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
<!-- Fixes #issue_id -->

#### Notes to the Reviewer

I tried to add this to the go test, however there is no existing unit test with secrets as they probably require a running k8s cluster and end up in a npe.

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated  

