### PR TITLE
Remove set bind permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Main (unreleased)
 
 - Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Agent instance by 20MB.
   If Agent is running certain otelcol components, this reduction will not apply. (@ptodev)
+  
+### Other changes
+
+- Remove setcap for `cap_net_bind_service` to allow Agent to run in restricted environments.
+  Modern container runtimes allow binding to unprivileged ports as non-root. (@ptodev)
 
 v0.43.4 (2024-11-25)
 -----------------

--- a/cmd/grafana-agent/Dockerfile
+++ b/cmd/grafana-agent/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.opencontainers.image.source="https://github.com/grafana/agent"
 # Install dependencies needed at runtime.
 RUN <<EOF
   apt-get update
-  apt-get install -qy libsystemd-dev tzdata ca-certificates libcap2-bin
+  apt-get install -qy libsystemd-dev tzdata ca-certificates
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 EOF
 
@@ -53,7 +53,6 @@ RUN groupadd --gid $UID $USERNAME
 RUN useradd -m -u $UID -g $UID $USERNAME
 RUN chown -R $USERNAME:$USERNAME /etc/agent
 RUN chown -R $USERNAME:$USERNAME /bin/grafana-agent
-RUN setcap 'cap_net_bind_service=+ep' /bin/grafana-agent
 
 ENTRYPOINT ["/bin/grafana-agent"]
 ENV AGENT_DEPLOY_MODE=docker


### PR DESCRIPTION
Porting [this fix](https://github.com/grafana/alloy/pull/726) from Alloy to Agent. It is requested by users whose Agents fail to start due to a "operation not permitted" error.

The reason why Agent requests `cap_net_bind_service` is that it listens on port 80 [by default](https://github.com/grafana/agent/blob/d26ecfdc9c50fc23e4577ca58cdf1b9401c60cb8/operations/helm/charts/grafana-agent/values.yaml#L54). Thus, if someone configures Alloy with the non-root user with ID 473, they'd need that capability. However, this is As the Alloy issue states, Docker has been enabling that capability by default for a long time now. So even for non-root users we wouldn't really need to set it.

Since only non-root users would encounter this, and non-root support is experimental, it's ok to remove the capability anyway.