### PR TITLE
Remove Pyroscope scrape loops for no longer active targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Main (unreleased)
 - `loki.source.podlogs`: Fixed a bug which prevented clustering from working and caused duplicate logs to be sent.
   The bug only happened when no `selector` or `namespace_selector` blocks were specified in the Agent configuration. (@ptodev)
 
+- `pyroscope.scrape` no longer tries to scrape endpoints which are not active targets anymore. (@wildum @mattdurham @dehaansa @ptodev)
+
 ### Enhancements
 
 - Upgrade `github.com/goccy/go-json` to v0.10.4, which reduces the memory consumption of an Agent instance by 20MB.

--- a/internal/component/pyroscope/scrape/manager.go
+++ b/internal/component/pyroscope/scrape/manager.go
@@ -103,6 +103,14 @@ func (m *Manager) reload() {
 			wg.Done()
 		}(m.targetsGroups[setName], groups)
 	}
+
+	for tgName, sp := range m.targetsGroups {
+		if _, ok := m.targetSets[tgName]; !ok {
+			sp.stop()
+			delete(m.targetsGroups, tgName)
+		}
+	}
+
 	wg.Wait()
 }
 


### PR DESCRIPTION
Porting [a fix from Alloy](https://github.com/grafana/alloy/pull/1833).