### PR TITLE
Update netframework link destinations

### DIFF
--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -263,14 +263,14 @@ Name     | Description | Enabled by default
 [mscluster_resourcegroup](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mscluster_resourcegroup.md) | MSCluster ResourceGroup metrics |
 [msmq](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.msmq.md) | MSMQ queues |
 [mssql](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.mssql.md) | [SQL Server Performance Objects](https://docs.microsoft.com/en-us/sql/relational-databases/performance-monitor/use-sql-server-objects#SQLServerPOs) metrics  |
-[netframework_clrexceptions](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrexceptions.md) | .NET Framework CLR Exceptions |
-[netframework_clrinterop](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrinterop.md) | .NET Framework Interop Metrics |
-[netframework_clrjit](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrjit.md) | .NET Framework JIT metrics |
-[netframework_clrloading](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrloading.md) | .NET Framework CLR Loading metrics |
-[netframework_clrlocksandthreads](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrlocksandthreads.md) | .NET Framework locks and metrics threads |
-[netframework_clrmemory](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrmemory.md) |  .NET Framework Memory metrics |
-[netframework_clrremoting](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrremoting.md) | .NET Framework Remoting metrics |
-[netframework_clrsecurity](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework_clrsecurity.md) | .NET Framework Security Check metrics |
+[netframework_clrexceptions](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-exceptions) | .NET Framework CLR Exceptions |
+[netframework_clrinterop](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-interop) | .NET Framework Interop Metrics |
+[netframework_clrjit](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-jit) | .NET Framework JIT metrics |
+[netframework_clrloading](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-loading) | .NET Framework CLR Loading metrics |
+[netframework_clrlocksandthreads](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-locks-and-threads) | .NET Framework locks and metrics threads |
+[netframework_clrmemory](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-memory) |  .NET Framework Memory metrics |
+[netframework_clrremoting](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-remoting) | .NET Framework Remoting metrics |
+[netframework_clrsecurity](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md#clr-security) | .NET Framework Security Check metrics |
 [net](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.net.md) | Network interface I/O | &#10003;
 [os](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.os.md) | OS metrics (memory, processes, users) | &#10003;
 [physical_disk](https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.physical_disk.md) | Physical disks | &#10003;

--- a/docs/sources/flow/reference/components/prometheus.exporter.windows.md
+++ b/docs/sources/flow/reference/components/prometheus.exporter.windows.md
@@ -66,15 +66,15 @@ text_file      | [text_file][]      | Configures the text_file collector.      |
 [dfsr]: #dfsr-block
 [exchange]: #exchange-block
 [iis]: #iis-block
-[logical_disk]: #logicaldisk-block
+[logical_disk]: #logical_disk-block
 [msmq]: #msmq-block
 [mssql]: #mssql-block
 [network]: #network-block
 [process]: #process-block
-[scheduled_task]: #scheduledtask-block
+[scheduled_task]: #scheduled_task-block
 [service]: #service-block
 [smtp]: #smtp-block
-[text_file]: #textfile-block
+[text_file]: #text_file-block
 
 ### dfsr block
 


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Document URL:
https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.exporter.windows/#collectors-list

The netframework_* links reference a nonexistent file.  They should link to https://github.com/prometheus-community/windows_exporter/blob/master/docs/collector.netframework.md


#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
Fixes [#14217](https://github.com/grafana/support-escalations/issues/14217)

#### Notes to the Reviewer

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated