### PR TITLE
Use GITHUB_TOKEN for backport job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Run backport
         uses: ./actions/backport
         with:
-          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           labelsToAdd: "backport"
           title: "[{{base}}] {{originalTitle}}"


### PR DESCRIPTION
The backport workflow has been [broken](https://github.com/grafana/agent/actions/runs/13591420160/job/37998236410). Hopefully this change which will fix it. It [fixed](https://github.com/grafana/alloy/pull/60) the backport job in Alloy a few months ago.

I didn't test this change. But since the workflow is already broken, I think it's worth a try to merge it and see if it helps.