### PR TITLE
upgrade golangci-lint for the base image

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -16,7 +16,7 @@ ARG GO_RUNTIME=mustoverride
 
 # Dependency: golangci-lint (for linting)
 FROM alpine as golangci
-RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.54.2
+RUN wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v2.0.2
 
 # Dependency: docker (for building images)
 FROM alpine:3.17 as docker


### PR DESCRIPTION
With the upgrade of the go version from 1.22 to 1.24 we need to upgrade the golangci-lint in the base image

v2.0.2 will require a change of the .golangci.yml