### PR TITLE
ci: stop using windows-2019 runners

### DIFF
--- a/.github/workflows/check-windows-build-image.yml
+++ b/.github/workflows/check-windows-build-image.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     paths:
       - 'build-image/windows/**'
+      - '.github/workflows/check-windows-build-image.yml'
 
 permissions:
   contents: read
 
 jobs:
   check-windows-build-image:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
The windows-2019 runners are deprecated as of 2025-06-01 and will be fully unsupported by 2025-06-30. There will be multiple brown-outs over the course of this month which might affect builds and releases unless we remove those runners.

See https://github.com/actions/runner-images/issues/12045 for details.