### PR TITLE
chore: Update build image go version to 1.25.7

### DIFF
--- a/.github/workflows/check-linux-build-image.yml
+++ b/.github/workflows/check-linux-build-image.yml
@@ -29,7 +29,7 @@ jobs:
           tags: grafana/agent-build-image:latest
           platforms: 'linux/amd64,linux/arm64'
           build-args: |
-            GO_RUNTIME=golang:1.24.11-bookworm
+            GO_RUNTIME=golang:1.25.7-bookworm
 
       - name: Check Linux boringcrypto build image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
@@ -39,4 +39,4 @@ jobs:
           tags: grafana/agent-build-image:latest
           platforms: 'linux/amd64,linux/arm64'
           build-args: |
-            GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.24.11-bookworm
+            GO_RUNTIME=mcr.microsoft.com/oss/go/microsoft/golang:1.25.7-bookworm

--- a/.github/workflows/update-build-images.yml
+++ b/.github/workflows/update-build-images.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       matrix:
         build:
-          - runtime: golang:1.24.11-bookworm
-          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.24.11-bookworm
+          - runtime: golang:1.25.7-bookworm
+          - runtime: mcr.microsoft.com/oss/go/microsoft/golang:1.25.7-bookworm
             suffix: "-boringcrypto"
     steps:
       - name: Checkout code 🛎️

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -4,7 +4,7 @@
 # default when running `docker buildx build` or when DOCKER_BUILDKIT=1 is set
 # in environment variables.
 
-# NOTE: The GO_RUNTIME is used to switch between the default Google go runtime and mcr.microsoft.com/oss/go/microsoft/golang:1.24.11-bookworm which is a Microsoft
+# NOTE: The GO_RUNTIME is used to switch between the default Google go runtime and mcr.microsoft.com/oss/go/microsoft/golang:1.25.7-bookworm which is a Microsoft
 # fork of go that allows using windows crypto instead of boring crypto. Details at https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips
 ARG GO_RUNTIME=mustoverride
 

--- a/build-image/windows/Dockerfile
+++ b/build-image/windows/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/golang:1.24.11-windowsservercore-ltsc2022
+FROM library/golang:1.25.7-windowsservercore-ltsc2022
 
 SHELL ["powershell", "-command"]
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,11 +11,11 @@ include docs.mk
 docs: check-cloudwatch-integration
 
 check-cloudwatch-integration:
-	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.24.11-bookworm go run static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/static/configuration/integrations/cloudwatch-exporter-config.md
-	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.24.11-bookworm go run static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
+	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.25.7-bookworm go run static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/static/configuration/integrations/cloudwatch-exporter-config.md
+	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.25.7-bookworm go run static/integrations/cloudwatch_exporter/docs/doc.go check /docs/sources/flow/reference/components/prometheus.exporter.cloudwatch.md
 
 generate-cloudwatch-integration:
-	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.24.11-bookworm go run static/integrations/cloudwatch_exporter/docs/doc.go generate
+	$(PODMAN) run -v $(shell git rev-parse --show-toplevel):/repo -v $(shell pwd):/docs -w /repo golang:1.25.7-bookworm go run static/integrations/cloudwatch_exporter/docs/doc.go generate
 
 sources/assets/hierarchy.svg: sources/operator/hierarchy.dot
 	cat $< | $(PODMAN) run --rm -i nshine/dot dot -Tsvg > $@


### PR DESCRIPTION
To address [CVE-2025-68121](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/cves/details/CVE-2025-68121)