### PR TITLE
operator: set DirectoryOrCreate on the logs daemonset data hostPath

### DIFF
--- a/static/operator/resources_logs.go
+++ b/static/operator/resources_logs.go
@@ -6,6 +6,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func hostPathTypePtr(t v1.HostPathType) *v1.HostPathType { return &t }
+
 func generateLogsDaemonSet(
 	cfg *Config,
 	name string,
@@ -56,10 +58,18 @@ func logsPodTemplateOptions() podTemplateOptions {
 				},
 			},
 			{
-				// Needed for storing positions for recovery.
+				// Needed for storing positions for recovery. Use
+				// DirectoryOrCreate so the node creates the directory
+				// on first scheduling; otherwise the DaemonSet Pod
+				// fails with `bind source path does not exist:
+				// /var/lib/grafana-agent/data` the first time the
+				// operator runs on a node (grafana/agent#6926).
 				Name: "data",
 				VolumeSource: v1.VolumeSource{
-					HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/grafana-agent/data"},
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/var/lib/grafana-agent/data",
+						Type: hostPathTypePtr(v1.HostPathDirectoryOrCreate),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

`generateLogsDaemonSet` wires `/var/lib/grafana-agent/data` into the collector Pod via a `hostPath` volume without specifying a `Type`. The kubelet defaults to `Directory` semantics, which requires the path to exist on the node before the container starts. The first time the operator schedules a logs DaemonSet onto a fresh node the Pod fails to start with:

```
invalid mount config for type "bind": bind source path does not exist:
/var/lib/grafana-agent/data
```

…and the Pod loops in `ContainerCreateError` until someone `mkdir`s the path on every node.

## Fix

Set `Type: DirectoryOrCreate` so the kubelet creates the directory (with the documented permissions) on first scheduling. Introduces a small `hostPathTypePtr` helper because `v1.HostPathType` is a non-addressable named string.

Fixes #6926.

## Test

- `go build ./static/operator/...` green.
- `go test ./static/operator/... -count=1 -short` passes.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>
