### PR TITLE
docs: fix prometheus.scrape typo in flow release notes

### DIFF
--- a/docs/sources/flow/release-notes.md
+++ b/docs/sources/flow/release-notes.md
@@ -369,7 +369,7 @@ remote.http "example" {
     url = URL_CONTAINING_TARGETS
 }
 
-prometehus.scrape "example" {
+prometheus.scrape "example" {
     targets    = discovery_target_decode(remote.http.example.content)
     forward_to = FORWARD_LIST
 }
@@ -382,7 +382,7 @@ discovery.http "example" {
     url = URL_CONTAINING_TARGETS
 }
 
-prometehus.scrape "example" {
+prometheus.scrape "example" {
     targets    = discovery.http.example.targets
     forward_to = FORWARD_LIST
 }


### PR DESCRIPTION
#### PR Description

Fixes a typo (`prometehus.scrape` -> `prometheus.scrape`) in two River configuration code examples in `docs/sources/flow/release-notes.md`.

#### Which issue(s) this PR fixes

N/A (trivial docs typo fix)

#### Notes to the Reviewer

Single-character typo fix in two code-block examples (around lines 372 and 385) within the Flow release notes. No functional changes.

#### PR Checklist

- [ ] CHANGELOG.md updated
- [ ] Documentation added
- [ ] Tests updated
- [ ] Config converters updated